### PR TITLE
メール登録に認証メール送信機能実装（開発環境）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ group :development do
 
   gem 'erb_lint', require: false
 
+  gem 'letter_opener_web'
+
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.4)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -144,6 +146,17 @@ GEM
       railties (>= 6.0.0)
     json (2.9.1)
     language_server-protocol (3.17.0.3)
+    launchy (3.1.0)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -334,6 +347,7 @@ DEPENDENCIES
   erb_lint
   jbuilder
   jsbundling-rails
+  letter_opener_web
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,6 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :confirmable
 end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,17 @@
+<p>こんにちは、<%= @resource.email %> さん</p>
+
+<p>KORESUKIをご利用いただきありがとうございます。</p>
+
+<p>以下のリンクをクリックすると、メールアドレスの登録が完了します。</p>
+
+<hr>
+
+<p>
+  <%= link_to 'メールアドレスを登録する', confirmation_url(@resource, confirmation_token: @token) %>
+</p>
+
+<hr>
+
+<p>※このメールに心当たりがない場合は、破棄してください。</p>
+
+<p>今後とも KORESUKI をよろしくお願いいたします。</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,11 +37,15 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  config.action_mailer.delivery_method = :letter_opener_web
+
+  config.action_mailer.perform_deliveries = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'staticpages#top'
+
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/db/migrate/20250126104659_add_confirmable_to_users.rb
+++ b/db/migrate/20250126104659_add_confirmable_to_users.rb
@@ -1,0 +1,10 @@
+class AddConfirmableToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string
+
+    add_index :users, :confirmation_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_26_071623) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_26_104659) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -24,6 +24,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_26_071623) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 実装タスク
#44 
## 実施内容
・deviseデフォルトの機能を使用して、メール登録時に認証メールを送信する機能実装
・usersテーブルに、必要カラム追加
・gem letter_openerインストール、設定
・送信メールの文章を修正
## 備考
・これから本番環境の機能実装