### PR TITLE
修正：認証メールがgmailの迷惑メールに分類されてしまう

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,0 +1,8 @@
+class CustomDeviseMailer < Devise::Mailer
+  default from: 'koresuki.info@gmail.com' # 送信元を変更
+
+  def confirmation_instructions(record, token, opts = {})
+    opts[:subject] = '【KORESUKI】メールアドレスの確認' # 件名をカスタマイズ
+    super
+  end
+end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,17 +1,23 @@
-<p>こんにちは、<%= @resource.email %> さん</p>
+<p>KORESUKIをご利用いただき、誠にありがとうございます。</p>
 
-<p>KORESUKIをご利用いただきありがとうございます。</p>
+<p>以下のリンクから、メールアドレスの確認をお願いいたします。</p>
 
-<p>以下のリンクをクリックすると、メールアドレスの登録が完了します。</p>
-
-<hr>
+<p>---------------------------------</p>
 
 <p>
-  <%= link_to 'メールアドレスを登録する', confirmation_url(@resource, confirmation_token: @token) %>
+  <%= link_to 'メールアドレスを確認する', confirmation_url(@resource, confirmation_token: @token) %>
 </p>
 
-<hr>
+<p>---------------------------------</p>
 
-<p>※このメールに心当たりがない場合は、破棄してください。</p>
+<p>ご不明な点がございましたら、以下のサポートメールアドレスまでご連絡ください。</p>
+
+<p>
+  KORESUKIサポート: <a href="mailto:koresuki.info@gmail.com">koresuki.info@gmail.com</a>
+</p>
 
 <p>今後とも KORESUKI をよろしくお願いいたします。</p>
+
+<p>※本メールは KORESUKI にご登録いただいた方に自動送信されています。</p>
+
+<p>※本メールにお心当たりのない方は、お手数ですが削除をお願いいたします。</p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,6 +26,8 @@ Devise.setup do |config|
   # with default "from" parameter.
   config.mailer_sender = Rails.application.credentials.dig(:gmail, :username)
 
+  config.mailer = 'CustomDeviseMailer'
+
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 


### PR DESCRIPTION
## 実装タスク
#44 
## 実施内容
認証メールがgmailの迷惑メールに分類されてしまうため、以下の修正を実施
・カスタムメーラーを作成して、メールに件名を追加
・メール文章内容を、スパム判定されないように修正
## 備考