### PR TITLE
追加：フラッシュメッセージの設定

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
-end
+	def flash_class(key)
+		case key.to_sym # key が文字列でも対応できるように to_sym で変換
+		when :notice then "bg-green-500 text-white p-4 rounded-md"
+		when :alert  then "bg-red-500 text-white p-4 rounded-md"
+		else "bg-blue-500 text-white p-4 rounded-md"
+	  end
+	end
+  end
+  

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,15 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
+   <div id="error_explanation"
+       class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-md shadow-md mb-4"
+       role="alert"
+       data-turbo-cache="false">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: devise_i18n_fix_model_name_case(resource.model_name.human, i18n_key: 'errors.messages.not_saved'))
        %>
     </h2>
-    <ul>
+    <ul class="mt-2 list-disc list-inside">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,12 +17,9 @@
       <%= render 'shared/header_before_login' %>
     <% end %>
 
-      <% if notice.present? %>
-        <p class="notice"><%= notice %></p>
-      <% end %>
-      <% if alert.present? %>
-        <p class="alert"><%= alert %></p>
-      <% end %>
+    <% flash.each do |key, message| %>
+    <p class="<%= flash_class(key) %>"><%= message %></p>
+    <% end %>
 
     <%= yield %>
     <%= render 'shared/footer' %>


### PR DESCRIPTION
## issue番号
closes #51 
## やったこと
・フラッシュメッセージのデザインを追加（tailwind）
・バリデーションエラーメッセージのデザインを追加（tailwind）
## やらなかったこと・できなかったこと
## できるようになること（ユーザー目線）
・ユーザー登録完了、ログイン、ログアウト時などのフラッシュメッセージの視認性が向上（背景緑色に）
・ユーザー登録時のバリデーションエラーメッセージの視認性が向上（背景赤色に）
## できなくなること（ユーザー目線）
## 動作確認
・上記動作を実施して、メッセージを確認（開発環境）
・本番環境はマージ後動作確認
## その他
・フラッシュメッセージはapplication.htmlをすっきりさせたいため、ヘルパーでメソッド定義
・nameカラムのバリデーションの未設定を確認したため、次のタスクで、バリデーションを設定する
・バリデーションエラーメッセージのi18n対応していなかったため、次のタスクで、i18対応実施する