### PR TITLE
追加：投稿新規作成機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,4 +2,24 @@ class PostsController < ApplicationController
   def index
     @posts = Post.includes(:user)
   end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = current_user.posts.build(post_params)
+    if @post.save
+      redirect_to posts_path, success: t('defaults.flash_message.created', item: Post.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.flash_message.not_created', item: Post.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :body)
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,7 +10,8 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      redirect_to posts_path, success: t('defaults.flash_message.created', item: Post.model_name.human)
+      flash[:success] = t('defaults.flash_message.created', item: Post.model_name.human)
+      redirect_to posts_path
     else
       flash.now[:danger] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,10 @@
 module ApplicationHelper
   def flash_class(key)
     case key.to_sym # key が文字列でも対応できるように to_sym で変換
-    when :notice then 'bg-green-500 text-white p-4 rounded-md'
-    when :alert  then 'bg-red-500 text-white p-4 rounded-md'
+    when :notice then "bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded-md shadow-md mb-4"
+    when :alert  then "bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-md shadow-md mb-4"
+    when :success then "bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded-md shadow-md mb-4"
+    when :danger then "bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-md shadow-md mb-4"
     else 'bg-blue-500 text-white p-4 rounded-md'
     end
   end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-3xl mx-auto mt-8">
-  <h1 class="text-2xl font-bold mb-6"><%= t('.title') %></h1>
+  <h1 class="text-2xl font-bold mb-6"><%= t("#{controller_path}.#{action_name}.title") %></h1>
   <%= form_with model: @post, class: "space-y-4" do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
     <div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,7 @@
 <div class="max-w-3xl mx-auto mt-8">
   <h1 class="text-2xl font-bold mb-6"><%= t('.title') %></h1>
   <%= form_with model: @post, class: "space-y-4" do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
     <div>
       <%= f.label :title, class: "block text-sm font-medium text-gray-700" %>
       <%= f.text_field :title, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,16 @@
+<div class="max-w-3xl mx-auto mt-8">
+  <h1 class="text-2xl font-bold mb-6"><%= t('.title') %></h1>
+  <%= form_with model: @post, class: "space-y-4" do |f| %>
+    <div>
+      <%= f.label :title, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_field :title, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+    <div>
+      <%= f.label :body, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_area :body, class: "mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500", rows: "10" %>
+    </div>
+	<div class="flex justify-center">
+    <%= f.submit nil, class: "bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300" %>
+	</div>
+  <% end %>
+</div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_explanation" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-md shadow-md mb-4">
+    <ul class="list-disc ml-4">
+      <% object.errors.each do |error| %>
+        <li class="text-sm"><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
     </div>
     <nav class="flex-none flex space-x-6">
       <%= link_to t('header.all_suki', default: 'みんなのSUKI'), posts_path, class: 'px-4 py-2' %>
-      <%= link_to t('header.post_suki', default: 'SUKI投稿'), '#', class: 'px-4 py-2' %>
+      <%= link_to t('header.post_suki', default: 'SUKI投稿'), new_post_path, class: 'px-4 py-2' %>
       <%= link_to t('header.mypage', default: 'マイページ'), '#', class: 'px-4 py-2' %>
       <%= link_to t('header.logout', default: 'ログアウト'), destroy_user_session_path, data: { turbo_method: :delete }, class: 'px-4 py-2' %>
     </nav>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,14 @@
+ja:
+  activerecord:
+    # モデル名
+    models:
+      user: ユーザー
+      post: 
+    # モデルの属性
+    attributes:
+      post:
+        title: SUKIのタイトル
+        body: SUKIの理由！
+    # errors.models: バリデーションエラー
+    errors:
+      models:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,13 +1,12 @@
 ja:
   # ビューファイル
-  views:
-    posts:
-      index:
-        title: "投稿一覧"
-      new:
-        title: "新規投稿"
-      edit:
-        title: "投稿を編集"
+  posts:
+    index:
+      title: 投稿一覧
+    new:
+      title: 新規投稿
+    edit:
+      title: 投稿を編集
   # ヘルパーメソッド
   helpers:
     submit:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,21 @@
+ja:
+  # ビューファイル
+  views:
+    posts:
+      index:
+        title: "投稿一覧"
+      new:
+        title: "新規投稿"
+      edit:
+        title: "投稿を編集"
+  # ヘルパーメソッド
+  helpers:
+    submit:
+      create: SUKIを投稿
+      update: SUKIを更新
+  defaults:
+    flash_message:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成出来ませんでした"
+      require_login: ログインしてください
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'staticpages#top'
 
-  resources :posts, only: %i[index]
+  resources :posts, only: %i[index new create]
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
## issue番号
closes #10 
## やったこと
・投稿新規作成機能実装
　- ルーティング、コントローラー、ビュー生成、編集
　- postモデルのバリデーションメッセージが表示されるようした
　- post作成成功、失敗時のフラッシュメッセージのデザイン修正（app/helpers/application_helper.rb）
　- ログイン後ヘッダーから、新規投稿画面へ動線確保
・i18nの相対キーがうまく反映されないため修正
## やらなかったこと・できなかったこと
・上記「i18nの相対キーがうまく反映されないため修正」の詳細（app/views/posts/new.html.erb）
　- 現在のコード（修正済み）
　```<%= t("#{controller_path}.#{action_name}.title") %>```
　```t('.title')```で相対キーを使用しようとしたが、反映されないため上記に修正
　原因：デバッグしたところ Looking for: [:ja, :posts, :title]と:newが相対キーに含まれず、反映されなかった
　根本的な解決に至っていない
## できるようになること（ユーザー目線）
・ヘッダーから新規投稿画面に遷移して新規投稿、投稿成功後は一覧画面に遷移
## できなくなること（ユーザー目線）
## 動作確認
・仮投稿をして、投稿が作成されているか確認
・投稿成功、失敗時のフラッシュメッセージ確認
・フォームを未入力にして投稿、バリデーションメッセージの確認
## その他
・現在postsテーブルはtitle、bodyカラムのみ