### PR TITLE
追加：投稿削除機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
 
-  protected
+  private
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -39,6 +39,13 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    @post = current_user.posts.find(params[:id])
+    @post.destroy!
+    flash[:notice] = t('defaults.flash_message.deleted', item: Post.model_name.human)
+    redirect_to posts_path
+  end
+
   private
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,10 +20,10 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      flash[:success] = t('defaults.flash_message.created', item: Post.model_name.human)
+      flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human)
       redirect_to posts_path
     else
-      flash.now[:danger] = t('defaults.flash_message.not_created', item: Post.model_name.human)
+      flash.now[:alert] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -31,10 +31,10 @@ class PostsController < ApplicationController
   def update
     @post = current_user.posts.find(params[:id])
     if @post.update(post_params)
-      flash[:success] = t('defaults.flash_message.updated', item: Post.model_name.human)
+      flash[:notice] = t('defaults.flash_message.updated', item: Post.model_name.human)
       redirect_to post_path(@post)
     else
-      flash.now[:danger] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
+      flash.now[:alert] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,8 @@
 module ApplicationHelper
   def flash_class(key)
     case key.to_sym # key が文字列でも対応できるように to_sym で変換
-    when :notice, :success then 'bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded-md shadow-md mb-4'
-    when :alert, :danger then 'bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-md shadow-md mb-4'
+    when :notice then 'bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded-md shadow-md mb-4'
+    when :alert then 'bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-md shadow-md mb-4'
     else 'bg-blue-500 text-white p-4 rounded-md'
     end
   end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -25,14 +25,7 @@
         <li class="flex items-center">
           <span><%= post.body %></span>
         </li>
-        <%= link_to '#' do %>
-          <span>Edit</span>
-        <% end %>
-        <%= link_to '#', method: :delete, data: { confirm: '本当に削除しますか？' } do %>
-          <span>Delete</span>
-        <% end %>
       </div>
     </div>
-
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -16,7 +16,8 @@
   <% if user_signed_in? && current_user.own?(@post) %>
     <div>
       <%= link_to '✏️ 編集', edit_post_path(@post), class: 'btn btn-primary' %>
-      <%= link_to '🗑️ 削除', '#', method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn btn-danger' %>
+      <%= link_to '🗑️ 削除', post_path(@post),data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, 
+    class: 'btn btn-danger' %>
     </div>
   <% end %>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -19,4 +19,5 @@ ja:
       require_login: ログインしてください
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新できませんでした"
+      deleted: "%{item}を削除しました"
 


### PR DESCRIPTION
## issue番号
close #60
## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿削除機能を実装

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 自分が投稿した投稿を投稿詳細から削除できる機能を実装
- 一覧画面から、削除編集リンクを削除
- その他リファクター

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 自分が投稿した投稿を削除

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- 仮投稿して、削除できるか確認

## その他
<!-- レビュワーへの参考情報 -->
 -投稿一覧画面から、編集、削除リンクを削除
　編集、削除は投稿詳細、もしくは今後実装のマイページからのできるようにする予定

## 関連Issue
<!-- このPRが関連するIssue -->
