### PR TITLE
修正：本番環境でXシャア時に投稿画像が反映されないため修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -57,7 +57,7 @@ class PostsController < ApplicationController
 
   def prepare_meta_tags(post)
     image_url = if post.image.present?
-                  "#{request.base_url}#{post.image.mini.url}"
+                  "#{request.base_url}#{post.image.url}"
                 else
                     "#{request.base_url}/ogp/ogp.png?text=#{CGI.escape(post.title)}"
                 end
@@ -80,3 +80,5 @@ class PostsController < ApplicationController
                   }
   end
 end
+
+

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -15,8 +15,13 @@ class ImageUploader < CarrierWave::Uploader::Base
     %w[jpg jpeg gif png heic]
   end
 
-  process resize_to_fit: [600, 600]
+  process resize_to_fit: [1200, 630]
   process :convert_heic_to_jpg, if: :heic?
+
+  # version :ogp do
+  #   process resize_to_fill: [1200, 630]
+  #   process :convert_heic_to_jpg, if: :heic?
+  # end
 
   version :mini do
     process resize_to_fill: [400, 350]


### PR DESCRIPTION
## issue番号
#30 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 本番環境でXシェア時に投稿した画像が反映されなかったため修正
[![Image from Gyazo](https://i.gyazo.com/9c984f8fbe42a1ed46a6d98cec8d2272.png)](https://gyazo.com/9c984f8fbe42a1ed46a6d98cec8d2272)

## やったこと
<!-- このプルリクで何をしたのか？ -->
- carrierwaveのアップローダーで、デフォルトの保存サイズを[600, 600]に設定していたため、[1200, 630]に修正

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- XのOGPチェカーで確認
- マージ後、本番環境で要確認
[![Image from Gyazo](https://i.gyazo.com/073b14d15b153938390804ae061f64ad.jpg)](https://gyazo.com/073b14d15b153938390804ae061f64ad)

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
