### PR TITLE
修正：本番環境でXシェア時に投稿画像が反映されないため修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -57,7 +57,7 @@ class PostsController < ApplicationController
 
   def prepare_meta_tags(post)
     image_url = if post.image.present?
-                  "#{request.base_url}#{post.image.url}"
+                  "#{post.image.url}"
                 else
                     "#{request.base_url}/ogp/ogp.png?text=#{CGI.escape(post.title)}"
                 end


### PR DESCRIPTION
## issue番号
#65 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 本番環境でXシェア時に投稿画像が反映されないため修正

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 考えられる原因
　request.base_url を 不要に連結してしまっていた ため、OGP画像の誤ったURLを渡していた
- 修正点
　request.base_url を削除

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- Xでシェアしたときに 投稿画像が正しく表示されるようになる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- マージ後、本番環境で確認

## その他
<!-- レビュワーへの参考情報 -->
- OGP画像が期限付きの影響で長時間表示されない可能性がある、別Issueで検討

## 関連Issue
<!-- このPRが関連するIssue -->
