### PR TITLE
修正：postsテーブル削除し、uuidにして再度postsテーブル作成

### DIFF
--- a/db/migrate/20250216065142_drop_posts_table.rb
+++ b/db/migrate/20250216065142_drop_posts_table.rb
@@ -1,0 +1,15 @@
+class DropPostsTable < ActiveRecord::Migration[7.1]
+  def up
+    drop_table :posts, if_exists: true
+  end
+
+  def down
+    create_table :posts, id: :integer do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.string :title, null: false
+      t.text :body, null: false
+      t.string :image
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250216065657_create_posts_with_uuid.rb
+++ b/db/migrate/20250216065657_create_posts_with_uuid.rb
@@ -1,0 +1,14 @@
+class CreatePostsWithUuid < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+
+    create_table :posts, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.string :title, null: false
+      t.text :body, null: false
+      t.string :image
+      t.timestamps
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_05_101136) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_16_065657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "posts", force: :cascade do |t|
+  create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.string "title", null: false
     t.text "body", null: false


### PR DESCRIPTION
## issue番号


## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 公開システムのため、IDを推測されにくくする目的でpostsテーブルにも`uuid`を採用
- postsテーブルの主キーを`uuid`に変更するため、一度削除して再作成

## やったこと
<!-- このプルリクで何をしたのか？ -->
- postsテーブル削除
- 主キーを`uuid`に変更し、postsテーブルを再作成

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで画像投稿をテストし、投稿が正しく動作することを確認

## その他
<!-- レビュワーへの参考情報 -->
- テーブルの作り直しの経過を残すため、マイグレーションファイルで実行

## 関連Issue
<!-- このPRが関連するIssue -->
