### PR TITLE
追加：投稿にコメント機能

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,10 +2,10 @@ class CommentsController < ApplicationController
 	def create
 	  comment = current_user.comments.build(comment_params)
       if comment.save
-	  	flash[:notice] = t('.success')
+		flash[:notice] = t('defaults.flash_message.created', item: Comment.model_name.human)
         redirect_to post_path(comment.post)
       else
-	  	flash[:alert] = t('.failure')
+		flash[:alert] = t('defaults.flash_message.not_created', item: Comment.model_name.human)
         redirect_to post_path(comment.post)
       end
 	end
@@ -13,7 +13,7 @@ class CommentsController < ApplicationController
 	def destroy
 	  comment = current_user.comments.find(params[:id])
 	  comment.destroy!
-	  flash[:notice] = t('.success')
+	  flash[:notice] = t('defaults.flash_message.deleted', item: Comment.model_name.human)
 	  redirect_to post_path(comment.post)
 	end
   

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -20,6 +20,6 @@ class CommentsController < ApplicationController
 	private
   
 	def comment_params
-	  params.require(:comment).permit(:content).merge(post_id: params[:post_id])
+	  params.require(:comment).permit(:body).merge(post_id: params[:post_id])
 	end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,12 +1,14 @@
 class CommentsController < ApplicationController
 	def create
-	  comment = current_user.comments.build(comment_params)
-      if comment.save
+	# @post,@commentsはpots/showをレンダリングするために定義
+	  @post = Post.find(params[:post_id])
+	  @comments = @post.comments.includes(:user).order(created_at: :desc)
+	  @comment = current_user.comments.build(comment_params)
+      if @comment.save
 		flash[:notice] = t('defaults.flash_message.created', item: Comment.model_name.human)
-        redirect_to post_path(comment.post)
+        redirect_to post_path(@comment.post)
       else
-		flash[:alert] = t('defaults.flash_message.not_created', item: Comment.model_name.human)
-        redirect_to post_path(comment.post)
+        render 'posts/show', status: :unprocessable_entity
       end
 	end
   

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,27 +1,27 @@
 class CommentsController < ApplicationController
-	def create
-	# @post,@commentsはpots/showをレンダリングするために定義
-	  @post = Post.find(params[:post_id])
-	  @comments = @post.comments.includes(:user).order(created_at: :desc)
-	  @comment = current_user.comments.build(comment_params)
-      if @comment.save
-		flash[:notice] = t('defaults.flash_message.created', item: Comment.model_name.human)
-        redirect_to post_path(@comment.post)
-      else
-        render 'posts/show', status: :unprocessable_entity
-      end
-	end
-  
-	def destroy
-	  comment = current_user.comments.find(params[:id])
-	  comment.destroy!
-	  flash[:notice] = t('defaults.flash_message.deleted', item: Comment.model_name.human)
-	  redirect_to post_path(comment.post)
-	end
-  
-	private
-  
-	def comment_params
-	  params.require(:comment).permit(:body).merge(post_id: params[:post_id])
-	end
+  def create
+    # @post,@commentsはpots/showをレンダリングするために定義
+    @post = Post.find(params[:post_id])
+    @comments = @post.comments.includes(:user).order(created_at: :desc)
+    @comment = current_user.comments.build(comment_params)
+    if @comment.save
+      flash[:notice] = t('defaults.flash_message.created', item: Comment.model_name.human)
+      redirect_to post_path(@comment.post)
+    else
+      render 'posts/show', status: :unprocessable_entity
+    end
   end
+
+  def destroy
+    comment = current_user.comments.find(params[:id])
+    comment.destroy!
+    flash[:notice] = t('defaults.flash_message.deleted', item: Comment.model_name.human)
+    redirect_to post_path(comment.post)
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(post_id: params[:post_id])
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,25 @@
+class CommentsController < ApplicationController
+	def create
+	  comment = current_user.comments.build(comment_params)
+      if comment.save
+	  	flash[:notice] = t('.success')
+        redirect_to post_path(comment.post)
+      else
+	  	flash[:alert] = t('.failure')
+        redirect_to post_path(comment.post)
+      end
+	end
+  
+	def destroy
+	  comment = current_user.comments.find(params[:id])
+	  comment.destroy!
+	  flash[:notice] = t('.success')
+	  redirect_to post_path(comment.post)
+	end
+  
+	private
+  
+	def comment_params
+	  params.require(:comment).permit(:content).merge(post_id: params[:post_id])
+	end
+  end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,6 +9,8 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
     prepare_meta_tags(@post)
+    # @comment = Comment.new
+    @comments = @post.comments.includes(:user).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,7 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
     prepare_meta_tags(@post)
-    # @comment = Comment.new
+    @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :desc)
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  validates :content, presence: true, length: { maximum: 300 }
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,5 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
 
-  validates :content, presence: true, length: { maximum: 300 }
+  validates :body, presence: true, length: { maximum: 300 }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
          :confirmable
 
   has_many :posts, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,16 @@
+<div class="bg-white p-4 rounded-lg shadow mb-4">
+  <div class="flex justify-between items-center mb-2">
+    <span class="font-bold"><%= comment.user.name %></span>
+    <span class="text-gray-500 text-sm"><%= l comment.created_at, format: :long %></span>
+  </div>
+  
+  <p class="text-gray-700"><%= comment.content %></p>
+  
+  <% if current_user&.own?(comment) %>
+    <div class="mt-2 text-right">
+      <%= link_to "削除", post_comment_path(comment.post, comment),
+          data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+          class: "text-red-500 hover:text-red-700" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -3,14 +3,14 @@
     <span class="font-bold"><%= comment.user.name %></span>
     <span class="text-gray-500 text-sm"><%= l comment.created_at, format: :long %></span>
   </div>
-  
+
   <p class="text-gray-700"><%= comment.body %></p>
-  
+
   <% if current_user&.own?(comment) %>
     <div class="mt-2 text-right">
-      <%= link_to "削除", post_comment_path(comment.post, comment),
-          data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-          class: "text-red-500 hover:text-red-700" %>
+      <%= link_to t('comments.destroy.title'), post_comment_path(comment.post, comment),
+                  data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') },
+                  class: 'text-red-500 hover:text-red-700' %>
     </div>
   <% end %>
 </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -4,7 +4,7 @@
     <span class="text-gray-500 text-sm"><%= l comment.created_at, format: :long %></span>
   </div>
   
-  <p class="text-gray-700"><%= comment.content %></p>
+  <p class="text-gray-700"><%= comment.body %></p>
   
   <% if current_user&.own?(comment) %>
     <div class="mt-2 text-right">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,7 +1,7 @@
-<%= form_with(model: [post, @comment], class: "mt-4") do |f| %>
+<%= form_with(model: [post, @comment], class: 'mt-4') do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="mb-4">
-    <%= f.text_area :body, class: "w-full p-2 border rounded-lg", rows: 3, placeholder: t('comments.placeholder.body') %>
+    <%= f.text_area :body, class: 'w-full p-2 border rounded-lg', rows: 3, placeholder: t('comments.placeholder.body') %>
   </div>
-  <%= f.submit t('helpers.submit.create'), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+  <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' %>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,6 @@
+<%= form_with(model: [post, Comment.new], local: true, class: "mt-4") do |f| %>
+  <div class="mb-4">
+    <%= f.text_area :content, class: "w-full p-2 border rounded-lg", rows: 3, placeholder: "コメントを入力" %>
+  </div>
+  <%= f.submit "コメントする", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: [post, Comment.new], local: true, class: "mt-4") do |f| %>
   <div class="mb-4">
-    <%= f.text_area :body, class: "w-full p-2 border rounded-lg", rows: 3, placeholder: "コメントを入力" %>
+    <%= f.text_area :body, class: "w-full p-2 border rounded-lg", rows: 3, placeholder: t('comments.placeholder.body') %>
   </div>
-  <%= f.submit "コメントする", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+  <%= f.submit t('helpers.submit.create'), class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
 <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,4 +1,5 @@
-<%= form_with(model: [post, Comment.new], local: true, class: "mt-4") do |f| %>
+<%= form_with(model: [post, @comment], class: "mt-4") do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
   <div class="mb-4">
     <%= f.text_area :body, class: "w-full p-2 border rounded-lg", rows: 3, placeholder: t('comments.placeholder.body') %>
   </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: [post, Comment.new], local: true, class: "mt-4") do |f| %>
   <div class="mb-4">
-    <%= f.text_area :content, class: "w-full p-2 border rounded-lg", rows: 3, placeholder: "コメントを入力" %>
+    <%= f.text_area :body, class: "w-full p-2 border rounded-lg", rows: 3, placeholder: "コメントを入力" %>
   </div>
   <%= f.submit "コメントする", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,6 +14,6 @@
   </div>
 
   <div class="flex justify-center">
-  <%= f.submit nil, class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>
+  <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>
   </div>
 <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,4 +1,4 @@
 <div class="max-w-3xl mx-auto mt-8">
-  <h1 class="text-2xl font-bold mb-6"><%= t("#{controller_path}.#{action_name}.title") %></h1>
+  <h1 class="text-2xl font-bold mb-6"><%= t('.title') %></h1>
   <%= render 'form', post: @post %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,8 +4,8 @@
       <!-- 検索フォーム -->
       <form>
         <div class="flex mb-3">
-          <input type="search" placeholder="検索ワード" autocomplete="on" class="flex-grow px-4 py-2 border rounded-l">
-          <input type="submit" value="検索" class="px-4 py-2 border rounded-r">
+          <input type="search" placeholder="<%= t('.search_placeholder') %>" autocomplete="on" class="flex-grow px-4 py-2 border rounded-l">
+          <input type="submit" value="<%= t('.search_submit') %>" class="px-4 py-2 border rounded-r">
         </div>
       </form>
     </div>
@@ -15,12 +15,12 @@
   <div class="mt-6">
     <% if @posts.present? %>
       <div class="space-y-4">
-        <div class="flex flex-wrap -mx-2"> <!-- 投稿を3列表示にする -->
+        <div class="flex flex-wrap -mx-2">
           <%= render @posts %>
         </div>
       </div>
     <% else %>
-      <div class="text-center">掲示板がありません</div>
+      <div class="text-center"><%= t('.no_posts') %></div>
     <% end %>
   </div>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,4 @@
 <div class="max-w-3xl mx-auto mt-8">
-  <h1 class="text-2xl font-bold mb-6"><%= t("#{controller_path}.#{action_name}.title") %></h1>
+  <h1 class="text-2xl font-bold mb-6"><%= t('.title') %></h1>
   <%= render 'form', post: @post %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,6 +3,7 @@
 
   <h1>「<%= @post.title %>」</h1>
 
+<!-- 投稿画像 -->
   <% if @post.image.present? %>
     <img src="<%= @post.image %>" alt="投稿画像">
   <% else %>
@@ -11,8 +12,8 @@
     </div>
   <% end %>
 
+  <!-- 投稿内容 -->
   <p><%= @post.body %></p>
-
 
   <!-- Xシェアボタン -->
   <div class="text-gray-600">
@@ -24,7 +25,7 @@
     <% end %>
   </div>
 
-  <!-- 編集・削除（投稿者の-->
+  <!-- 編集・削除（投稿者のみ)-->
   <% if user_signed_in? && current_user.own?(@post) %>
     <div>
       <%= link_to '✏️ 編集', edit_post_path(@post), class: 'btn btn-primary' %>
@@ -35,15 +36,13 @@
 
   <!-- コメントフォーム -->
   <div class="mt-8">
-    <h3 class="text-xl font-bold mb-4">コメント</h3>
-
+    <h3 class="text-xl font-bold mb-4"><%= t('comments.create.title') %></h3>
     <% if user_signed_in? %>
       <%= render 'comments/form', post: @post %>
     <% end %>
-
   <!-- コメント一覧 -->
     <div class="mt-6">
-      <%= render @post.comments %>
+      <%= render @comments %>
     </div>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -13,6 +13,8 @@
 
   <p><%= @post.body %></p>
 
+
+  <!-- Xシェアボタン -->
   <div class="text-gray-600">
     <% encode_text = URI.encode_www_form_component("【KORESUKI】\nわたしの好き「#{@post.title}」を投稿しました！") %>
     <% twitter_share_url = "https://twitter.com/intent/tweet?url=#{CGI.escape(post_url(@post))}&text=#{encode_text}%0A%0A&hashtags=KORESUKI" %>
@@ -22,6 +24,7 @@
     <% end %>
   </div>
 
+  <!-- 編集・削除（投稿者の-->
   <% if user_signed_in? && current_user.own?(@post) %>
     <div>
       <%= link_to '✏️ 編集', edit_post_path(@post), class: 'btn btn-primary' %>
@@ -29,4 +32,18 @@
                                              class: 'btn btn-danger' %>
     </div>
   <% end %>
+
+  <!-- コメントフォーム -->
+  <div class="mt-8">
+    <h3 class="text-xl font-bold mb-4">コメント</h3>
+
+    <% if user_signed_in? %>
+      <%= render 'comments/form', post: @post %>
+    <% end %>
+
+  <!-- コメント一覧 -->
+    <div class="mt-6">
+      <%= render @post.comments %>
+    </div>
+  </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -29,7 +29,7 @@
   <% if user_signed_in? && current_user.own?(@post) %>
     <div>
       <%= link_to '✏️ 編集', edit_post_path(@post), class: 'btn btn-primary' %>
-      <%= link_to '🗑️ 削除', post_path(@post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' },
+      <%= link_to '🗑️ 削除', post_path(@post), data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') },
                                              class: 'btn btn-danger' %>
     </div>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <h2><%= @post.user.name %> さんの SUKI</h2>
+  <h2><%= @post.user.name %> <%= t('.title') %></h2>
 
   <h1>「<%= @post.title %>」</h1>
 
@@ -19,18 +19,17 @@
   <div class="text-gray-600">
     <% encode_text = URI.encode_www_form_component("【KORESUKI】\nわたしの好き「#{@post.title}」を投稿しました！") %>
     <% twitter_share_url = "https://twitter.com/intent/tweet?url=#{CGI.escape(post_url(@post))}&text=#{encode_text}%0A%0A&hashtags=KORESUKI" %>
-      <%= link_to twitter_share_url, target: '_blank', class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded',
-                                     title: 'Xでシェア', rel: 'noopener' do %>
-      <span>Share on X</span>
+      <%= link_to twitter_share_url, target: '_blank', rel: 'noopener', class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' do %>
+      <span><%= t('helpers.submit.xshare') %></span>
     <% end %>
   </div>
 
   <!-- 編集・削除（投稿者のみ)-->
   <% if user_signed_in? && current_user.own?(@post) %>
     <div>
-      <%= link_to '✏️ 編集', edit_post_path(@post), class: 'btn btn-primary' %>
-      <%= link_to '🗑️ 削除', post_path(@post), data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') },
-                                             class: 'btn btn-danger' %>
+      <%= link_to t('helpers.submit.edit'), edit_post_path(@post), class: 'btn btn-primary' %>
+      <%= link_to t('helpers.submit.delete'), post_path(@post), data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') },
+                                                                class: 'btn btn-danger' %>
     </div>
   <% end %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div class="mt-6">
-      <%= link_to t('.edit'), edit_user_registration_path, class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded' %>
+      <%= link_to t('helpers.submit.edit'), edit_user_registration_path, class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded' %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,9 +4,9 @@
     DaisyUI Debug: このテキストが **赤色** で、背景が **青色** なら DaisyUI は適用されています！
   </div>
     <nav>
-      <a><%= link_to 'お問い合わせ', '#', target: :_blank, rel: 'noopener noreferrer' %></a>
-      <a><%= link_to '利用規約', '#', target: :_blank, rel: 'noopener noreferrer' %></a>
-      <a><%= link_to 'プライバシーポリシー', '#', target: :_blank, rel: 'noopener noreferrer' %></a>
+      <a><%= link_to t('footer.contact'), '#', target: :_blank, rel: 'noopener noreferrer' %></a>
+      <a><%= link_to t('footer.terms'), '#', target: :_blank, rel: 'noopener noreferrer' %></a>
+      <a><%= link_to t('footer.privacy'), '#', target: :_blank, rel: 'noopener noreferrer' %></a>
     </nav>
   </div>
 </footer>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -4,6 +4,7 @@ ja:
     models:
       user: ユーザー
       post: 投稿
+      comment: コメント
     # モデルの属性
     attributes:
       post:

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,7 +9,7 @@ ja:
     attributes:
       post:
         title: SUKIのタイトル
-        body: SUKIの理由！
+        body: SUKIの理由
+      comment:
+        body: コメント
     # errors.models: バリデーションエラー
-    errors:
-      models:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,13 +25,16 @@ ja:
       failure: 'コメントの投稿に失敗しました'
     destroy:
       success: 'コメントを削除しました'
+      title: 削除
     placeholder:
       body: コメントを入力
-  # ヘルパーメソッド
+  # 共通
   helpers:
     submit:
       create: 投稿
       update: 更新
+    confirm:
+      delete: 本当に削除しますか？
   defaults:
     flash_message:
       created: "%{item}を作成しました"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,13 +5,22 @@ ja:
     post_suki: SUKI投稿
     mypage: マイページ
     logout: ログアウト
+  footer:
+    contact: お問い合わせ
+    terms: 利用規約
+    privacy: プライバシーポリシー
   posts:
     index:
       title: 投稿一覧
+      no_posts: 掲示板がありません
+      search_placeholder: 検索ワード
+      search_submit: 検索
     new:
       title: 新規投稿
     edit:
-      title: 投稿を編集
+      title: 投稿編集
+    show:
+      title: さんのSUKI
   profiles:
     show:
       title: さんのプロフィール
@@ -33,6 +42,9 @@ ja:
     submit:
       create: 投稿
       update: 更新
+      edit: 編集
+      delete: 削除
+      xshare: Xシェア
     confirm:
       delete: 本当に削除しますか？
   defaults:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,11 +18,20 @@ ja:
       name: 名前
       email: メールアドレス
       edit: 編集
+  comments:
+    create:
+      title: コメント
+      success: 'コメントを投稿しました'
+      failure: 'コメントの投稿に失敗しました'
+    destroy:
+      success: 'コメントを削除しました'
+    placeholder:
+      body: コメントを入力
   # ヘルパーメソッド
   helpers:
     submit:
-      create: SUKIを投稿
-      update: SUKIを更新
+      create: 投稿
+      update: 更新
   defaults:
     flash_message:
       created: "%{item}を作成しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,11 @@ Rails.application.routes.draw do
   root 'staticpages#top'
 
   resources :posts do
-    resources :likes, only: [:create, :destroy]
+    resources :likes, only: %i[create destroy]
+    resources :comments, only: %i[create edit update destroy]
   end
 
-  resource :profile, only: [:show, :edit, :update]
+  resource :profile, only: %i[show edit update]
 
   get 'ogp/ogp.png', to: 'ogp_images#show', as: :ogp_image
 

--- a/db/migrate/20250218111445_create_comments.rb
+++ b/db/migrate/20250218111445_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :comments, id: :uuid do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :post, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250218111445_create_comments.rb
+++ b/db/migrate/20250218111445_create_comments.rb
@@ -1,7 +1,7 @@
 class CreateComments < ActiveRecord::Migration[7.1]
   def change
     create_table :comments, id: :uuid do |t|
-      t.text :content, null: false
+      t.text :body, null: false
       t.references :user, null: false, foreign_key: true, type: :uuid
       t.references :post, null: false, foreign_key: true, type: :uuid
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_18_111445) do
   enable_extension "plpgsql"
 
   create_table "comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "content", null: false
+    t.text "body", null: false
     t.uuid "user_id", null: false
     t.uuid "post_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_16_101642) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_18_111445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "content", null: false
+    t.uuid "user_id", null: false
+    t.uuid "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
 
   create_table "likes", force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -53,6 +63,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_16_101642) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"


### PR DESCRIPTION
## issue番号
closes #72 
closes #73 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿にコメント作成、削除機能追加（ログインユーザーのみ）
- コメントの閲覧は未ログインでも可能（作成、削除はログイン必須)

## やったこと
<!-- このプルリクで何をしたのか？ -->
- commentsテーブル作成
- モデルの関連付け（1対多）を設定
- ルーティングを追加（postsにネスト）
- commentsコントローラ作成、実装
- ファイル全体のi18n対応を実施

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- コメント編集機能（今後別issueで対応）

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- ログインユーザーは投稿詳細ぺージでコメント作成、削除できる
- 未ログインユーザーもコメントを閲覧可能

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルでコメント作成、削除挙動確認
- バリデーションエラーメッセージの挙動も確認
- i18nが適応されていることを確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
