### PR TITLE
修正：uuidに変更して、likesテーブル再作成

### DIFF
--- a/db/migrate/20250221095710_recreate_likes_with_uuid.rb
+++ b/db/migrate/20250221095710_recreate_likes_with_uuid.rb
@@ -1,0 +1,31 @@
+class RecreateLikesWithUuid < ActiveRecord::Migration[7.0]
+  def up
+    drop_table :likes, if_exists: true
+
+    create_table :likes, id: :uuid do |t|
+      t.uuid :user_id, null: false
+      t.uuid :likeable_id, null: false
+      t.string :likeable_type, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index ["likeable_id", "likeable_type"], name: "index_likes_on_likeable"
+      t.index ["user_id", "likeable_id", "likeable_type"], name: "index_likes_on_user_id_and_likeable", unique: true
+      t.index ["user_id"], name: "index_likes_on_user_id"
+    end
+  end
+
+  def down
+    drop_table :likes, if_exists: true
+
+    create_table :likes do |t|
+      t.bigint :user_id, null: false
+      t.bigint :likeable_id, null: false
+      t.string :likeable_type, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index ["likeable_id", "likeable_type"], name: "index_likes_on_likeable"
+      t.index ["user_id", "likeable_id", "likeable_type"], name: "index_likes_on_user_id_and_likeable", unique: true
+      t.index ["user_id"], name: "index_likes_on_user_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_20_114549) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_21_095710) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -25,12 +25,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_114549) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "likes", force: :cascade do |t|
+  create_table "likes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.uuid "likeable_id", null: false
     t.string "likeable_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["likeable_id", "likeable_type"], name: "index_likes_on_likeable"
     t.index ["user_id", "likeable_id", "likeable_type"], name: "index_likes_on_user_id_and_likeable", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
@@ -66,6 +66,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_114549) do
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
-  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## issue番号

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- likesテーブルの主キーをuuidに変更するため、likesテーブル削除して、再作成

## やったこと
<!-- このプルリクで何をしたのか？ -->
- likesテーブルの主キーをuuidに変更するため、likesテーブル削除して、再作成

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで投稿にいいね、いいね削除を押して挙動を確認
- コンソールでuuidでのデータ保存を確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->