### PR TITLE
追加：通知機能

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,7 @@ class CommentsController < ApplicationController
     @comments = @post.comments.includes(:user).order(created_at: :desc)
     @comment = current_user.comments.build(comment_params)
     if @comment.save
+      @comment.create_notification(current_user)
       flash[:notice] = t('defaults.flash_message.created', item: Comment.model_name.human)
       redirect_to post_path(@comment.post)
     else

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,7 +5,7 @@ class CommentsController < ApplicationController
     @comments = @post.comments.includes(:user).order(created_at: :desc)
     @comment = current_user.comments.build(comment_params)
     if @comment.save
-      @comment.create_notification(current_user)
+      @comment.create_notification(current_user, :commented)
       flash[:notice] = t('defaults.flash_message.created', item: Comment.model_name.human)
       redirect_to post_path(@comment.post)
     else

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,6 +3,7 @@ class LikesController < ApplicationController
 
   def create
     current_user.like(@likeable)
+    @likeable.create_notification(current_user, :liked)
     # create.turbo_stream.erbで、like-button-#{@likeable.id}を更新する
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,8 @@
+class NotificationsController < ApplicationController
+  def index
+    @notifications = current_user.passive_notifications
+                               .includes(:visitor, :notifiable)
+                               .order(created_at: :desc)
+    @notifications.where(checked: false).update_all(checked: true)
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,9 +2,13 @@ class NotificationsController < ApplicationController
   def index
     @notifications = current_user.passive_notifications
                                 # 通知を送ったuser、通知対象(postやcomment)を取得するためincludes
-                               .includes(:visitor, :notifiable)
-                               .includes(notifiable: [:post, :comment])
-                               .order(created_at: :desc)
+                                .includes(:visitor, { notifiable: [:post, :comment] })
+                                .order(created_at: :desc)
     @notifications.where(checked: false).update_all(checked: true)
+  end
+
+  def destroy
+    current_user.passive_notifications.destroy_all
+    redirect_to notifications_path, notice: t('defaults.flash_message.deleted', item: Notification.model_name.human)
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,7 +3,9 @@ class NotificationsController < ApplicationController
     @notifications = current_user.passive_notifications
                                 # 通知を送ったuser、通知対象(postやcomment)を取得するためincludes
                                .includes(:visitor, :notifiable)
+                               .includes(notifiable: [:post, :comment])
                                .order(created_at: :desc)
     @notifications.where(checked: false).update_all(checked: true)
+ 
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,6 +6,5 @@ class NotificationsController < ApplicationController
                                .includes(notifiable: [:post, :comment])
                                .order(created_at: :desc)
     @notifications.where(checked: false).update_all(checked: true)
- 
   end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,7 @@
 class NotificationsController < ApplicationController
   def index
     @notifications = current_user.passive_notifications
+                                # 通知を送ったuser、通知対象(postやcomment)を取得するためincludes
                                .includes(:visitor, :notifiable)
                                .order(created_at: :desc)
     @notifications.where(checked: false).update_all(checked: true)

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,9 +1,9 @@
 class NotificationsController < ApplicationController
   def index
     @notifications = current_user.passive_notifications
-                                # 通知を送ったuser、通知対象(postやcomment)を取得するためincludes
-                                .includes(:visitor, { notifiable: [:post, :comment] })
-                                .order(created_at: :desc)
+                                 # 通知を送ったuser、通知対象(postやcomment)を取得するためincludes
+                                 .includes(:visitor, { notifiable: %i[post comment] })
+                                 .order(created_at: :desc)
     @notifications.where(checked: false).update_all(checked: true)
   end
 

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,28 +1,30 @@
 module NotificationsHelper
-	def notification_bell_icon
-	  if unread_notifications?
-		render_bell_icon(fill: 'yellow')
-	  else
-		render_bell_icon(fill: 'none')
-	  end
-	end
-  
-	private
-
-	def unread_notifications?
-		current_user.passive_notifications.where(checked: false).exists?
-	end
-  
-	def render_bell_icon(fill:)
-	  tag.svg(xmlns: "http://www.w3.org/2000/svg",
-			  fill: fill,
-			  viewBox: "0 0 24 24",
-			  'stroke-width': "1.5",
-			  stroke: "currentColor",
-			  class: "size-6") do
-		tag.path('stroke-linecap': "round",
-				 'stroke-linejoin': "round",
-				 d: "M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0")
-	  end
-	end
+  def notification_bell_icon
+    if unread_notifications?
+      render_bell_icon(fill: 'yellow')
+    else
+      render_bell_icon(fill: 'none')
+    end
   end
+
+  private
+
+  def unread_notifications?
+    current_user.passive_notifications.exists?(checked: false)
+  end
+
+  def render_bell_icon(fill:)
+    tag.svg(xmlns: 'http://www.w3.org/2000/svg',
+            fill: fill,
+            viewBox: '0 0 24 24',
+            'stroke-width': '1.5',
+            stroke: 'currentColor',
+            class: 'size-6') do
+      tag.path('stroke-linecap': 'round',
+               'stroke-linejoin': 'round',
+               d: 'M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 ' \
+                  '6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 ' \
+                  '0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0')
+    end
+  end
+end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,8 +1,4 @@
 module NotificationsHelper
-	def unread_notifications?
-	  current_user.passive_notifications.where(checked: false).exists?
-	end
-  
 	def notification_bell_icon
 	  if unread_notifications?
 		render_bell_icon(fill: 'yellow')
@@ -12,6 +8,10 @@ module NotificationsHelper
 	end
   
 	private
+
+	def unread_notifications?
+		current_user.passive_notifications.where(checked: false).exists?
+	end
   
 	def render_bell_icon(fill:)
 	  tag.svg(xmlns: "http://www.w3.org/2000/svg",

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,28 @@
+module NotificationsHelper
+	def unread_notifications?
+	  current_user.passive_notifications.where(checked: false).exists?
+	end
+  
+	def notification_bell_icon
+	  if unread_notifications?
+		render_bell_icon(fill: 'yellow')
+	  else
+		render_bell_icon(fill: 'none')
+	  end
+	end
+  
+	private
+  
+	def render_bell_icon(fill:)
+	  tag.svg(xmlns: "http://www.w3.org/2000/svg",
+			  fill: fill,
+			  viewBox: "0 0 24 24",
+			  'stroke-width': "1.5",
+			  stroke: "currentColor",
+			  class: "size-6") do
+		tag.path('stroke-linecap': "round",
+				 'stroke-linejoin': "round",
+				 d: "M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0")
+	  end
+	end
+  end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,12 +9,16 @@ class Comment < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: 300 }
 
-  def create_notification(visitor)
+  def create_notification(visitor, action)
     Notification.create!(
+      # visitorにはcurrent_user（コメントしたユーザー）が入る
       visitor_id: visitor.id,
+      # visitedにはpost.user（投稿者）が入る
       visited_id: post.user.id,
+      # notifiableにはself（コメント）が入る
       notifiable: self,
-      action: :commented
+      # actionにはaction（コメント）が入る
+      action: action
     )
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,15 +10,18 @@ class Comment < ApplicationRecord
   validates :body, presence: true, length: { maximum: 300 }
 
   def create_notification(visitor, action)
-    Notification.create!(
-      # visitorにはcurrent_user（コメントしたユーザー）が入る
-      visitor_id: visitor.id,
-      # visitedにはpost.user（投稿者）が入る
-      visited_id: post.user.id,
-      # notifiableにはself（コメント）が入る
-      notifiable: self,
-      # actionにはaction（コメント）が入る
-      action: action
-    )
+    # いいね、コメントしたユーザーと投稿者が同じ場合は通知を作成しない
+    return if visitor.id == post.user.id
+
+      Notification.create!(
+        # current_userが入る
+        visitor_id: visitor.id,
+        # 投稿者
+        visited_id: post.user.id,
+        # コメントが入る
+        notifiable: self,
+        # いいねかコメントが入る
+        action: action
+      )
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,15 +13,15 @@ class Comment < ApplicationRecord
     # いいね、コメントしたユーザーと投稿者が同じ場合は通知を作成しない
     return if visitor.id == post.user.id
 
-      Notification.create!(
-        # current_userが入る
-        visitor_id: visitor.id,
-        # 投稿者
-        visited_id: post.user.id,
-        # コメントが入る
-        notifiable: self,
-        # いいねかコメントが入る
-        action: action
-      )
+    Notification.create!(
+      # current_userが入る
+      visitor_id: visitor.id,
+      # 投稿者
+      visited_id: post.user.id,
+      # コメントが入る
+      notifiable: self,
+      # いいねかコメントが入る
+      action: action
+    )
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,5 +5,16 @@ class Comment < ApplicationRecord
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
 
+  has_many :notifications, as: :notifiable, dependent: :destroy
+
   validates :body, presence: true, length: { maximum: 300 }
+
+  def create_notification(visitor)
+    Notification.create!(
+      visitor_id: visitor.id,
+      visited_id: post.user.id,
+      notifiable: self,
+      action: :commented
+    )
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,10 +1,10 @@
 class Notification < ApplicationRecord
-	belongs_to :visitor, class_name: 'User'
-	belongs_to :visited, class_name: 'User'
-	belongs_to :notifiable, polymorphic: true
-  
-	validates :action, presence: true
-	validates :checked, inclusion: { in: [true, false] }
-  
-	enum action: { liked: 0, commented: 1 }
-  end
+  belongs_to :visitor, class_name: 'User', inverse_of: :active_notifications
+  belongs_to :visited, class_name: 'User', inverse_of: :passive_notifications
+  belongs_to :notifiable, polymorphic: true
+
+  validates :action, presence: true
+  validates :checked, inclusion: { in: [true, false] }
+
+  enum :action, { liked: 0, commented: 1 }
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,10 @@
+class Notification < ApplicationRecord
+	belongs_to :visitor, class_name: 'User'
+	belongs_to :visited, class_name: 'User'
+	belongs_to :notifiable, polymorphic: true
+  
+	validates :action, presence: true
+	validates :checked, inclusion: { in: [true, false] }
+  
+	enum action: { liked: 0, commented: 1 }
+  end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,12 +1,25 @@
 class Post < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
-  # ポリモーフィック関連付けに変更
+  
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
+
+  has_many :notifications, as: :notifiable, dependent: :destroy
 
   mount_uploader :image, ImageUploader
 
   validates :title, presence: true
   validates :body, presence: true
+
+  def create_notification(visitor, action)
+    notification = Notification.find_or_initialize_by(
+      visitor_id: visitor.id,
+      visited_id: user.id,
+      notifiable: self,
+      action: action
+    )
+
+    notification.save if notification.new_record?
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,6 +13,7 @@ class Post < ApplicationRecord
   validates :body, presence: true
 
   def create_notification(visitor, action)
+    # 通知が存在しない場合は新しく作成,いいねを複数回押しても1回分の通知しか作成されないように
     notification = Notification.find_or_initialize_by(
       visitor_id: visitor.id,
       visited_id: user.id,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,7 +13,10 @@ class Post < ApplicationRecord
   validates :body, presence: true
 
   def create_notification(visitor, action)
-    # 通知が存在しない場合は新しく作成,いいねを複数回押しても1回分の通知しか作成されないように
+    # いいね、コメントしたユーザーと投稿者が同じ場合は通知を作成しない
+    return if visitor.id == user.id
+    # find_or_initialize_by　既存のレコードを取得,存在しない場合は新しく作成
+    # いいねを複数回押しても1回分の通知しか作成されないように
     notification = Notification.find_or_initialize_by(
       visitor_id: visitor.id,
       visited_id: user.id,
@@ -21,6 +24,6 @@ class Post < ApplicationRecord
       action: action
     )
 
-    notification.save if notification.new_record?
+    notification.save
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
-  
+
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
 
@@ -15,6 +15,7 @@ class Post < ApplicationRecord
   def create_notification(visitor, action)
     # いいね、コメントしたユーザーと投稿者が同じ場合は通知を作成しない
     return if visitor.id == user.id
+
     # find_or_initialize_by　既存のレコードを取得,存在しない場合は新しく作成
     # いいねを複数回押しても1回分の通知しか作成されないように
     notification = Notification.find_or_initialize_by(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,10 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
-  has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
-  has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
+  has_many :active_notifications, class_name: 'Notification', inverse_of: :visitor, foreign_key: 'visitor_id', dependent: :destroy
+  has_many :passive_notifications, class_name: 'Notification', inverse_of: :visited, foreign_key: 'visited_id', dependent: :destroy
 
-  #　下記プロフィール画面で使用予定
+  # 　下記プロフィール画面で使用予定
   has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post', dependent: :destroy
   has_many :liked_comments, through: :likes, source: :likeable, source_type: 'Comment', dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,10 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
+  has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id', dependent: :destroy
+  has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id', dependent: :destroy
 
+  #　下記プロフィール画面で使用予定
   has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post', dependent: :destroy
   has_many :liked_comments, through: :likes, source: :likeable, source_type: 'Comment', dependent: :destroy
 

--- a/app/views/likes/_unlike_button.html.erb
+++ b/app/views/likes/_unlike_button.html.erb
@@ -1,7 +1,7 @@
 <% like = current_user.likes.find_by(likeable: likeable) %>
 <!-- destoryなので、like_idも渡す -->
 <%= link_to like_path(id: like.id, likeable_type: likeable.class.name, likeable_id: likeable.id), id: "unlike-button-#{likeable.id}",
-                                                                        data: { turbo_method: :delete }, class: 'btn btn-ghost' do %>
+                                                                                                  data: { turbo_method: :delete }, class: 'btn btn-ghost' do %>
   <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-red-500" fill="currentColor" viewBox="0 0 24 24" stroke="currentColor">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
   </svg>

--- a/app/views/notifications/_commented.html.erb
+++ b/app/views/notifications/_commented.html.erb
@@ -1,7 +1,7 @@
 <div class="flex items-center">
   <span class="font-semibold"><%= notification.visitor.name %></span>
   <span class="ml-2">
-    があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post) %>」にコメントしました
+    があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post), class: "text-blue-600 hover:text-blue-800 hover:underline" %>」にコメントしました
   </span>
   <span class="text-gray-500 text-sm ml-2">
     <%= l notification.created_at, format: :long %>

--- a/app/views/notifications/_commented.html.erb
+++ b/app/views/notifications/_commented.html.erb
@@ -1,7 +1,7 @@
 <div class="flex items-center">
   <span class="font-semibold"><%= notification.visitor.name %></span>
   <span class="ml-2">
-    があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post), class: "text-blue-600 hover:text-blue-800 hover:underline" %>」にコメントしました
+    があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にコメントしました
   </span>
   <span class="text-gray-500 text-sm ml-2">
     <%= l notification.created_at, format: :long %>

--- a/app/views/notifications/_commented.html.erb
+++ b/app/views/notifications/_commented.html.erb
@@ -1,0 +1,9 @@
+<div class="flex items-center">
+  <span class="font-semibold"><%= notification.visitor.name %></span>
+  <span class="ml-2">
+    があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post) %>」にコメントしました
+  </span>
+  <span class="text-gray-500 text-sm ml-2">
+    <%= l notification.created_at, format: :long %>
+  </span>
+</div>

--- a/app/views/notifications/_liked.html.erb
+++ b/app/views/notifications/_liked.html.erb
@@ -2,9 +2,9 @@
   <span class="font-semibold"><%= notification.visitor.name %></span>
   <span class="ml-2">
     <% if notification.notifiable_type == 'Post' %>
-      があなたの投稿「<%= link_to notification.notifiable.title, post_path(notification.notifiable) %>」にいいねしました
-    <% else %>
-      があなたのコメントにいいねしました
+      があなたの投稿「<%= link_to notification.notifiable.title, post_path(notification.notifiable), class: "text-blue-600 hover:text-blue-800 hover:underline" %>」にいいねしました
+    <% elsif notification.notifiable_type == 'Comment' %>
+      があなたのコメント「<%= link_to notification.notifiable.body, post_path(notification.notifiable.post), class: "text-blue-600 hover:text-blue-800 hover:underline" %>」にいいねしました
     <% end %>
   </span>
   <span class="text-gray-500 text-sm ml-2">

--- a/app/views/notifications/_liked.html.erb
+++ b/app/views/notifications/_liked.html.erb
@@ -2,9 +2,9 @@
   <span class="font-semibold"><%= notification.visitor.name %></span>
   <span class="ml-2">
     <% if notification.notifiable_type == 'Post' %>
-      があなたの投稿「<%= link_to notification.notifiable.title, post_path(notification.notifiable), class: "text-blue-600 hover:text-blue-800 hover:underline" %>」にいいねしました
+      があなたの投稿「<%= link_to notification.notifiable.title, post_path(notification.notifiable), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にいいねしました
     <% elsif notification.notifiable_type == 'Comment' %>
-      があなたのコメント「<%= link_to notification.notifiable.body, post_path(notification.notifiable.post), class: "text-blue-600 hover:text-blue-800 hover:underline" %>」にいいねしました
+      があなたのコメント「<%= link_to notification.notifiable.body, post_path(notification.notifiable.post), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にいいねしました
     <% end %>
   </span>
   <span class="text-gray-500 text-sm ml-2">

--- a/app/views/notifications/_liked.html.erb
+++ b/app/views/notifications/_liked.html.erb
@@ -1,0 +1,13 @@
+<div class="flex items-center">
+  <span class="font-semibold"><%= notification.visitor.name %></span>
+  <span class="ml-2">
+    <% if notification.notifiable_type == 'Post' %>
+      があなたの投稿「<%= link_to notification.notifiable.title, post_path(notification.notifiable) %>」にいいねしました
+    <% else %>
+      があなたのコメントにいいねしました
+    <% end %>
+  </span>
+  <span class="text-gray-500 text-sm ml-2">
+    <%= l notification.created_at, format: :long %>
+  </span>
+</div>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,3 +1,3 @@
 <div class="bg-white p-4 rounded-lg shadow <%= notification.checked? ? 'opacity-75' : '' %>">
-	<%= render "notifications/#{notification.action}", notification: notification %>
+  <%= render "notifications/#{notification.action}", notification: notification %>
 </div>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,3 @@
+<div class="bg-white p-4 rounded-lg shadow <%= notification.checked? ? 'opacity-75' : '' %>">
+	<%= render "notifications/#{notification.action}", notification: notification %>
+</div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <h2 class="text-2xl font-bold mb-6"><%= t('.title') %></h2>
   <% if @notifications.present? %>
-    <%= link_to "全削除",notification_path(@notifications), data: { turbo_method: :delete },class:"btn btn-light" %>
+    <%= link_to '全削除', notification_path(@notifications), data: { turbo_method: :delete }, class: 'btn btn-light' %>
     <div class="space-y-4">
       <%= render @notifications %>
     </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,15 @@
+<div class="container mx-auto px-4 py-8">
+  <h2 class="text-2xl font-bold mb-6"><%= t('.title') %></h2>
+
+  <% if @notifications.exists? %>
+    <div class="space-y-4">
+      <% @notifications.each do |notification| %>
+        <div class="bg-white p-4 rounded-lg shadow <%= notification.checked? ? 'opacity-75' : '' %>">
+          <%= render "notifications/#{notification.action}", notification: notification %>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="text-gray-500"><%= t('.no_notifications') %></p>
+  <% end %>
+</div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,6 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <h2 class="text-2xl font-bold mb-6"><%= t('.title') %></h2>
-  <% if @notifications.exists? %>
+  <% if @notifications.present? %>
+    <%= link_to "全削除",notification_path(@notifications), data: { turbo_method: :delete },class:"btn btn-light" %>
     <div class="space-y-4">
       <%= render @notifications %>
     </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,13 +1,8 @@
 <div class="container mx-auto px-4 py-8">
   <h2 class="text-2xl font-bold mb-6"><%= t('.title') %></h2>
-
   <% if @notifications.exists? %>
     <div class="space-y-4">
-      <% @notifications.each do |notification| %>
-        <div class="bg-white p-4 rounded-lg shadow <%= notification.checked? ? 'opacity-75' : '' %>">
-          <%= render "notifications/#{notification.action}", notification: notification %>
-        </div>
-      <% end %>
+      <%= render @notifications %>
     </div>
   <% else %>
     <p class="text-gray-500"><%= t('.no_notifications') %></p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,7 +4,9 @@
       <a><%= link_to 'KORESUKI', root_path %></a>
     </div>
     <nav class="flex-none flex space-x-6">
-      <%= link_to t('header.notifications'), notifications_path, class: 'px-4 py-2' %>
+      <%= link_to notifications_path, class: 'px-4 py-2 flex items-center gap-1' do %>
+        <%= notification_bell_icon %>
+      <% end %>
       <%= link_to t('header.all_suki'), posts_path, class: 'px-4 py-2' %>
       <%= link_to t('header.post_suki'), new_post_path, class: 'px-4 py-2' %>
       <%= link_to t('header.mypage'), profile_path, class: 'px-4 py-2' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,6 +4,7 @@
       <a><%= link_to 'KORESUKI', root_path %></a>
     </div>
     <nav class="flex-none flex space-x-6">
+      <%= link_to t('header.notifications'), notifications_path, class: 'px-4 py-2' %>
       <%= link_to t('header.all_suki'), posts_path, class: 'px-4 py-2' %>
       <%= link_to t('header.post_suki'), new_post_path, class: 'px-4 py-2' %>
       <%= link_to t('header.mypage'), profile_path, class: 'px-4 py-2' %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,6 +5,7 @@ ja:
       user: ユーザー
       post: 投稿
       comment: コメント
+      notification: 通知
     # モデルの属性
     attributes:
       post:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,7 +5,6 @@ ja:
     post_suki: SUKI投稿
     mypage: マイページ
     logout: ログアウト
-    notifications: 通知
   footer:
     contact: お問い合わせ
     terms: 利用規約

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,6 +5,7 @@ ja:
     post_suki: SUKI投稿
     mypage: マイページ
     logout: ログアウト
+    notifications: 通知
   footer:
     contact: お問い合わせ
     terms: 利用規約
@@ -37,6 +38,10 @@ ja:
       title: 削除
     placeholder:
       body: コメントを入力
+  notifications:
+    index:
+      title: 通知
+      no_notifications: 通知がありません
   # 共通
   helpers:
     submit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
 
   resource :profile, only: %i[show edit update]
 
+  resources :notifications, only: %i[index]
+
   get 'ogp/ogp.png', to: 'ogp_images#show', as: :ogp_image
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   resource :profile, only: %i[show edit update]
 
-  resources :notifications, only: %i[index]
+  resources :notifications, only: %i[index destroy]
 
   get 'ogp/ogp.png', to: 'ogp_images#show', as: :ogp_image
 

--- a/db/migrate/20250222110240_create_notifications.rb
+++ b/db/migrate/20250222110240_create_notifications.rb
@@ -1,0 +1,13 @@
+class CreateNotifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notifications, id: :uuid do |t|
+      t.references :visitor, null: false, foreign_key: { to_table: :users }, type: :uuid
+      t.references :visited, null: false, foreign_key: { to_table: :users }, type: :uuid
+      t.references :notifiable, polymorphic: true, null: false, type: :uuid
+      t.integer :action, null: false
+      t.boolean :checked, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_21_095710) do
   enable_extension "plpgsql"
 
   create_table "comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "content", null: false
+    t.text "body", null: false
     t.uuid "user_id", null: false
     t.uuid "post_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_21_095710) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_22_110240) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -34,6 +34,20 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_21_095710) do
     t.index ["likeable_id", "likeable_type"], name: "index_likes_on_likeable"
     t.index ["user_id", "likeable_id", "likeable_type"], name: "index_likes_on_user_id_and_likeable", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "notifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "visitor_id", null: false
+    t.uuid "visited_id", null: false
+    t.string "notifiable_type", null: false
+    t.uuid "notifiable_id", null: false
+    t.integer "action", null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["visited_id"], name: "index_notifications_on_visited_id"
+    t.index ["visitor_id"], name: "index_notifications_on_visitor_id"
   end
 
   create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -66,5 +80,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_21_095710) do
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "notifications", "users", column: "visited_id"
+  add_foreign_key "notifications", "users", column: "visitor_id"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## issue番号
closes #78
closes #79
closes #80
## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 通知機能の実装
- 通知が発生する条件
　- 自分の投稿にいいね、コメントがつく
　- 自分のコメントにいいねがつく
　- 例外：自分の投稿に自らいいねやコメントした場合は通知が発生しない
- 通知の削除機能の実装
## やったこと
<!-- このプルリクで何をしたのか？ -->
- `notifications`テーブルの作成
- ルーティングの追加
- `notifications`モデルの作成、ポリモーフィック関連付けの実施（`post`、`user`、`comment`）
- 通知の`view`ファイル作成（一部`helper`に切り出し）
- ヘッダーに通知一覧への導線確保（`heroicons`）（未読の場合はアイコンを黄色に設定）
- 通知削除機能の実装
- `lint`の修正実施
## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし
## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 自分の投稿にいいね、コメントがついた場合に通知を受け取れる
- 自分のコメントにいいねがついた場合に通知を受け取れる
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし
## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- 他人の投稿にいいね、コメント、コメントにいいねをして通知の挙動を確認
- 自分自身の投稿にいいね、コメント、コメントにいいねをした場合に通知が発生しないことを確認
## その他
<!-- レビュワーへの参考情報 -->
- なし
## 関連Issue
<!-- このPRが関連するIssue -->