### PR TITLE
更新:アップロードされる画像ファイル形式をwebpに変換する

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -12,36 +12,28 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w[jpg jpeg gif png heic]
+    %w[jpg jpeg gif png heic webp]
   end
 
   process resize_to_fit: [1200, 630]
-  process :convert_heic_to_jpg, if: :heic?
+  process :convert_to_webp
 
   version :mini do
     process resize_to_fill: [400, 350]
-    process :convert_heic_to_jpg, if: :heic?
+    process :convert_to_webp
   end
 
   private
 
-  def heic?(file)
-    file.extension.downcase == 'heic'
-  end
-
-  def convert_heic_to_jpg
+  def convert_to_webp
     manipulate! do |img|
-      img.format('jpg')
+      img.format('webp')
       img
     end
   end
 
   # 内部的に呼び出されるメソッド,filenameをオーバーライドしている
-  def filename
-    return if super.blank? # CarrierWave のデフォルトの filename が存在するか確認
-
-    base_name = File.basename(super, '.*')
-    extension = File.extname(super).downcase == '.heic' ? 'jpg' : File.extname(super).downcase.delete('.')
-    "#{base_name}.#{extension}"
+ def filename
+    super.chomp(File.extname(super)) + '.webp' if original_filename.present?
   end
 end


### PR DESCRIPTION
## issue番号
close #82 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- アップロードされる画像ファイル形式をwebpに変換するロジックに変更
　- 既存のコードではheic形式のみ、jpegに変換していた

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `app/uploaders/image_uploader.rb`編集

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 投稿作成時のアップロード時間の短縮

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- s3に画像保存をして、画像サイズの縮小を確認
[![Image from Gyazo](https://i.gyazo.com/5ae0d7bed55173ada810e288c55a4839.png)](https://gyazo.com/5ae0d7bed55173ada810e288c55a4839)
[![Image from Gyazo](https://i.gyazo.com/203fdaee2c13ab25dfd776a8c1db58a5.png)](https://gyazo.com/203fdaee2c13ab25dfd776a8c1db58a5)
## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
