### PR TITLE
追加：サブ画像投稿機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,6 +15,7 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    @post.post_images.build
   end
 
   def edit; end
@@ -49,7 +50,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :body, :image)
+    params.require(:post).permit(:title, :body, :image, post_images_attributes: [:id, :image, :caption, :_destroy])
   end
 
   def set_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -54,7 +54,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :body, :image, post_images_attributes: [:id, :image, :caption, :_destroy])
+    params.require(:post).permit(:title, :body, :image, post_images_attributes: %i[id image caption _destroy])
   end
 
   def set_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,7 +18,9 @@ class PostsController < ApplicationController
     @post.post_images.build
   end
 
-  def edit; end
+  def edit
+    @post.post_images.build
+  end
 
   def create
     @post = current_user.posts.build(post_params)
@@ -37,6 +39,7 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.updated', item: Post.model_name.human)
       redirect_to post_path(@post)
     else
+      @post.post_images.build
       flash.now[:alert] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -26,6 +26,7 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human)
       redirect_to posts_path
     else
+      @post.post_images.build
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,6 +5,7 @@ class Post < ApplicationRecord
   has_many :liked_users, through: :likes, source: :user
   has_many :notifications, as: :notifiable, dependent: :destroy
   has_many :post_images, dependent: :destroy
+  accepts_nested_attributes_for :post_images, allow_destroy: true, reject_if: :all_blank
 
   mount_uploader :image, ImageUploader
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,11 +1,10 @@
 class Post < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
-
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
-
   has_many :notifications, as: :notifiable, dependent: :destroy
+  has_many :post_images, dependent: :destroy
 
   mount_uploader :image, ImageUploader
 

--- a/app/models/post_image.rb
+++ b/app/models/post_image.rb
@@ -1,6 +1,5 @@
 class PostImage < ApplicationRecord
-	belongs_to :post
+  belongs_to :post
 
-	mount_uploader :image, PostImageUploader
-
+  mount_uploader :image, PostImageUploader
 end

--- a/app/models/post_image.rb
+++ b/app/models/post_image.rb
@@ -1,4 +1,6 @@
 class PostImage < ApplicationRecord
 	belongs_to :post
-	
+
+	mount_uploader :image, PostImageUploader
+
 end

--- a/app/models/post_image.rb
+++ b/app/models/post_image.rb
@@ -1,0 +1,4 @@
+class PostImage < ApplicationRecord
+	belongs_to :post
+	
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -33,7 +33,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   # 内部的に呼び出されるメソッド,filenameをオーバーライドしている
- def filename
-    super.chomp(File.extname(super)) + '.webp' if original_filename.present?
+  def filename
+    "#{super.chomp(File.extname(super))}.webp" if original_filename.present?
   end
 end

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -28,7 +28,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
   end
 
   # 内部的に呼び出されるメソッド,filenameをオーバーライドしている
- def filename
-    super.chomp(File.extname(super)) + '.webp' if original_filename.present?
+  def filename
+    "#{super.chomp(File.extname(super))}.webp" if original_filename.present?
   end
 end

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -1,0 +1,34 @@
+class PostImageUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
+
+  if Rails.env.production?
+    storage :fog # 本番環境ではS3に保存
+  else
+    storage :file # 開発・テスト環境ではローカルに保存
+  end
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def extension_allowlist
+    %w[jpg jpeg gif png heic webp]
+  end
+
+  process resize_to_fit: [1000, 750]
+  process :convert_to_webp
+
+  private
+
+  def convert_to_webp
+    manipulate! do |img|
+      img.format('webp')
+      img
+    end
+  end
+
+  # 内部的に呼び出されるメソッド,filenameをオーバーライドしている
+ def filename
+    super.chomp(File.extname(super)) + '.webp' if original_filename.present?
+  end
+end

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -15,7 +15,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
     %w[jpg jpeg gif png heic webp]
   end
 
-  process resize_to_fit: [1000, 750]
+  process resize_to_fit: [500, 500]
   process :convert_to_webp
 
   private

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -3,5 +3,7 @@
   <div class="mb-4">
     <%= f.text_area :body, class: 'w-full p-2 border rounded-lg', rows: 3, placeholder: t('comments.placeholder.body') %>
   </div>
-  <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' %>
+  <div class="flex justify-center">
+    <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' %>
+  </div>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,15 +12,18 @@
     <%= f.label :image, class: 'block text-sm font-medium text-gray-700' %>
     <%= f.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
   </div>
+  <!-- サブ画像 -->
   <div>
     <%= f.fields_for :post_images do |post_image_form| %>
       <div class="mb-4">
         <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+        <%= post_image_form.file_field :image,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
       </div>
       <div class="mb-4">
         <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+        <%= post_image_form.text_field :caption,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
       </div>
     <% end %>
   </div>
@@ -28,11 +31,13 @@
     <%= f.fields_for :post_images do |post_image_form| %>
       <div class="mb-4">
         <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+        <%= post_image_form.file_field :image,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
       </div>
       <div class="mb-4">
         <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+        <%= post_image_form.text_field :caption,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
       </div>
     <% end %>
   </div>
@@ -40,15 +45,17 @@
     <%= f.fields_for :post_images do |post_image_form| %>
       <div class="mb-4">
         <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+        <%= post_image_form.file_field :image,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
       </div>
       <div class="mb-4">
         <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+        <%= post_image_form.text_field :caption,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
       </div>
     <% end %>
   </div>
-
+  <!-- 投稿ボタン -->
   <div class="flex justify-center">
   <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>
   </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -24,6 +24,30 @@
       </div>
     <% end %>
   </div>
+  <div>
+    <%= f.fields_for :post_images do |post_image_form| %>
+      <div class="mb-4">
+        <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+      <div class="mb-4">
+        <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+    <% end %>
+  </div>
+    <div>
+    <%= f.fields_for :post_images do |post_image_form| %>
+      <div class="mb-4">
+        <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+      <div class="mb-4">
+        <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+    <% end %>
+  </div>
 
   <div class="flex justify-center">
   <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -55,6 +55,20 @@
       </div>
     <% end %>
   </div>
+      <div>
+    <%= f.fields_for :post_images do |post_image_form| %>
+      <div class="mb-4">
+        <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_image_form.file_field :image,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+      <div class="mb-4">
+        <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_image_form.text_field :caption,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+    <% end %>
+  </div>
   <!-- 投稿ボタン -->
   <div class="flex justify-center">
   <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,6 +12,18 @@
     <%= f.label :image, class: 'block text-sm font-medium text-gray-700' %>
     <%= f.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
   </div>
+  <div>
+    <%= f.fields_for :post_images do |post_image_form| %>
+      <div class="mb-4">
+        <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+      <div class="mb-4">
+        <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+    <% end %>
+  </div>
 
   <div class="flex justify-center">
   <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,32 +1,36 @@
-<div>
-  <h2><%= @post.user.name %> <%= t('.title') %></h2>
+<div class="container mx-auto max-w-4xl px-4 py-8">
+  <h2 class="text-center"><%= @post.user.name %> <%= t('.title') %></h2>
 
-  <h1>「<%= @post.title %>」</h1>
+  <h1 class="text-center text-2xl font-bold my-4">「<%= @post.title %>」</h1>
 
 <!-- メイン画像 -->
-  <% if @post.image.present? %>
-    <img src="<%= @post.image.url %>" alt="メイン画像">
-  <% else %>
-    <div style="width: 300px; height: 200px; background-color: lightgray; text-align: center; line-height: 200px;">
-      写真
-    </div>
-  <% end %>
+  <div class="flex justify-center my-6">
+    <% if @post.image.present? %>
+      <img src="<%= @post.image.url %>" alt="メイン画像" class="max-w-full">
+    <% else %>
+      <div style="width: 300px; height: 200px; background-color: lightgray; text-align: center; line-height: 200px;">
+        写真
+      </div>
+    <% end %>
+  </div>
 
   <!-- 投稿内容 -->
-  <p><%= @post.body %></p>
+  <p class="my-6 text-center"><%= @post.body %></p>
 
   <!-- サブ画像 -->
   <% if @post.post_images.present? %>
-    <% @post.post_images.each do |post_image| %>
-      <img src="<%= post_image.image.url %>" alt="サブ画像">
-      <% if post_image.caption.present? %>
-        <p><%= post_image.caption %></p>
+    <div class="flex flex-col items-center my-6">
+      <% @post.post_images.each do |post_image| %>
+        <img src="<%= post_image.image.url %>" alt="サブ画像" class="max-w-full mb-2">
+        <% if post_image.caption.present? %>
+          <p class="mb-4 text-center"><%= post_image.caption %></p>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   <% end %>
 
   <!-- Xシェアボタン -->
-  <div class="text-gray-600">
+  <div class="flex justify-center my-6">
     <% encode_text = URI.encode_www_form_component("【KORESUKI】\nわたしの好き「#{@post.title}」を投稿しました！") %>
     <% twitter_share_url = "https://twitter.com/intent/tweet?url=#{CGI.escape(post_url(@post))}&text=#{encode_text}%0A%0A&hashtags=KORESUKI" %>
       <%= link_to twitter_share_url, target: '_blank', rel: 'noopener', class: 'bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' do %>
@@ -36,7 +40,7 @@
 
   <!-- コメントフォーム -->
   <div class="mt-8">
-    <h3 class="text-xl font-bold mb-4"><%= t('comments.create.title') %></h3>
+    <h3 class="text-xl font-bold mb-4 text-center"><%= t('comments.create.title') %></h3>
     <% if user_signed_in? %>
       <%= render 'comments/form', post: @post %>
     <% end %>
@@ -48,7 +52,7 @@
 
   <!-- 編集・削除（投稿者のみ)-->
   <% if user_signed_in? && current_user.own?(@post) %>
-    <div>
+    <div class="flex justify-center gap-4 mt-6">
       <%= link_to t('helpers.submit.edit'), edit_post_path(@post), class: 'btn btn-primary' %>
       <%= link_to t('helpers.submit.delete'), post_path(@post), data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') },
                                                                 class: 'btn btn-danger' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,9 +3,9 @@
 
   <h1>「<%= @post.title %>」</h1>
 
-<!-- 投稿画像 -->
+<!-- メイン画像 -->
   <% if @post.image.present? %>
-    <img src="<%= @post.image %>" alt="投稿画像">
+    <img src="<%= @post.image.url %>" alt="メイン画像">
   <% else %>
     <div style="width: 300px; height: 200px; background-color: lightgray; text-align: center; line-height: 200px;">
       写真
@@ -15,6 +15,16 @@
   <!-- 投稿内容 -->
   <p><%= @post.body %></p>
 
+  <!-- サブ画像 -->
+  <% if @post.post_images.present? %>
+    <% @post.post_images.each do |post_image| %>
+      <img src="<%= post_image.image.url %>" alt="サブ画像">
+      <% if post_image.caption.present? %>
+        <p><%= post_image.caption %></p>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <!-- Xシェアボタン -->
   <div class="text-gray-600">
     <% encode_text = URI.encode_www_form_component("【KORESUKI】\nわたしの好き「#{@post.title}」を投稿しました！") %>
@@ -23,15 +33,6 @@
       <span><%= t('helpers.submit.xshare') %></span>
     <% end %>
   </div>
-
-  <!-- 編集・削除（投稿者のみ)-->
-  <% if user_signed_in? && current_user.own?(@post) %>
-    <div>
-      <%= link_to t('helpers.submit.edit'), edit_post_path(@post), class: 'btn btn-primary' %>
-      <%= link_to t('helpers.submit.delete'), post_path(@post), data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') },
-                                                                class: 'btn btn-danger' %>
-    </div>
-  <% end %>
 
   <!-- コメントフォーム -->
   <div class="mt-8">
@@ -44,4 +45,13 @@
       <%= render @comments %>
     </div>
   </div>
+
+  <!-- 編集・削除（投稿者のみ)-->
+  <% if user_signed_in? && current_user.own?(@post) %>
+    <div>
+      <%= link_to t('helpers.submit.edit'), edit_post_path(@post), class: 'btn btn-primary' %>
+      <%= link_to t('helpers.submit.delete'), post_path(@post), data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') },
+                                                                class: 'btn btn-danger' %>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -11,6 +11,10 @@ ja:
       post:
         title: SUKIのタイトル
         body: SUKIの理由
+        image: メイン画像（Xシェア、みんなのSUKIに反映されます）
       comment:
         body: コメント
+      post_image:
+        image: サブ画像
+        caption: サブ画像の説明文
     # errors.models: バリデーションエラー

--- a/db/migrate/20250226051325_create_post_images.rb
+++ b/db/migrate/20250226051325_create_post_images.rb
@@ -3,7 +3,7 @@ class CreatePostImages < ActiveRecord::Migration[7.1]
     create_table :post_images, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
       t.references :post, null: false, foreign_key: true, type: :uuid
       t.string :image
-      t.string :caption
+      t.text :caption
 
       t.timestamps
     end

--- a/db/migrate/20250226051325_create_post_images.rb
+++ b/db/migrate/20250226051325_create_post_images.rb
@@ -1,0 +1,11 @@
+class CreatePostImages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_images, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.references :post, null: false, foreign_key: true, type: :uuid
+      t.string :image
+      t.string :caption
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_26_051325) do
   enable_extension "plpgsql"
 
   create_table "comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "body", null: false
+    t.text "content", null: false
     t.uuid "user_id", null: false
     t.uuid "post_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,7 +53,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_26_051325) do
   create_table "post_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "post_id", null: false
     t.string "image"
-    t.string "caption"
+    t.text "caption"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_post_images_on_post_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_22_110240) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_26_051325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -50,6 +50,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_22_110240) do
     t.index ["visitor_id"], name: "index_notifications_on_visitor_id"
   end
 
+  create_table "post_images", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "post_id", null: false
+    t.string "image"
+    t.string "caption"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_post_images_on_post_id"
+  end
+
   create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.string "title", null: false
@@ -82,5 +91,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_22_110240) do
   add_foreign_key "comments", "users"
   add_foreign_key "notifications", "users", column: "visited_id"
   add_foreign_key "notifications", "users", column: "visitor_id"
+  add_foreign_key "post_images", "posts"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## issue番号
close #84 
close #85 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿にメイン画像の他に、サブ画像を複数枚投稿できる機能を実装
- サブ画像には説明文を追加できる

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `post_imagas`テーブルを作成（カラム　image(string)、caption(text)(説明文))
- `post`モデルと関連付け（一対多）
- `PostImage`アップローダー作成、マウント
　- [500, 500]にリサイズ、webpに変換
- `posts`コントローラーでparamsを許可
- `_form.html`で画像投稿フォームを作成
- `show.html`でサブ画像表示
- lint修正

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 投稿にメイン画像の他にサブ画像を複数枚投稿できる（現時点では最大4枚）
- サブ画像に説明文を投稿できる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- サブ画像投稿して、挙動を確認
- S3の画像保存を確認
- 新規投稿、投稿更新失敗時に、説明文がリセットされないことを確認

## その他
<!-- レビュワーへの参考情報 -->
- 現時点ではサブ画像の投稿は上限4枚だが、動的にフォームを追加できる機能を検討

## 関連Issue
<!-- このPRが関連するIssue -->
