### PR TITLE
修正:投稿失敗時にサブ画像のフォームが増えてしまうエラーを修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,11 +15,13 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
-    @post.post_images.build
+    4.times { @post.post_images.build } # 4つの空のフォームを作成
   end
 
   def edit
-    @post.post_images.build
+    # 常に4つのフォームを表示するため、不足分のオブジェクトを追加
+    # 既存の画像,説明文がある場合はそれを保持し、合計が4つになるように
+    (4 - @post.post_images.size).times { @post.post_images.build }
   end
 
   def create
@@ -28,7 +30,9 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human)
       redirect_to posts_path
     else
-      @post.post_images.build
+      # バリデーション失敗時、常に4つのフォームを表示するため不足分を追加
+      # 送信されたデータは保持しつつ、合計が4つになるように
+      (4 - @post.post_images.size).times { @post.post_images.build }
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
@@ -39,7 +43,7 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.updated', item: Post.model_name.human)
       redirect_to post_path(@post)
     else
-      @post.post_images.build
+      (4 - @post.post_images.size).times { @post.post_images.build }
       flash.now[:alert] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -27,48 +27,6 @@
       </div>
     <% end %>
   </div>
-  <div>
-    <%= f.fields_for :post_images do |post_image_form| %>
-      <div class="mb-4">
-        <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.file_field :image,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-      </div>
-      <div class="mb-4">
-        <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.text_field :caption,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-      </div>
-    <% end %>
-  </div>
-    <div>
-    <%= f.fields_for :post_images do |post_image_form| %>
-      <div class="mb-4">
-        <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.file_field :image,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-      </div>
-      <div class="mb-4">
-        <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.text_field :caption,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-      </div>
-    <% end %>
-  </div>
-      <div>
-    <%= f.fields_for :post_images do |post_image_form| %>
-      <div class="mb-4">
-        <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.file_field :image,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-      </div>
-      <div class="mb-4">
-        <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.text_field :caption,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-      </div>
-    <% end %>
-  </div>
   <!-- 投稿ボタン -->
   <div class="flex justify-center">
   <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>


### PR DESCRIPTION
## issue番号
close #84 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿失敗時にエラーが発生したため修正、下記エラーの状況
　- 投稿失敗した時に、サブ画像の投稿フォームが増えてしまう（4つ→8つ）
　- createアクションだけでなく、upadateアクション時も同様に発生

## やったこと
<!-- このプルリクで何をしたのか？ -->
#### 原因　
- `_form.html`で`<%= f.fields_for :post_images do |post_image_form| %>`を4つ使用していたため、投稿失敗後に
`posts_controller`の `else@post.post_images.build`で新規のフォームを追加でbuildしてしまっていた
-  `_form.html`で`<%= f.fields_for :post_images do |post_image_form| %>`を4つ使用することは、一つのレコードに対して4つの送信フォームがあるという状況で、エラーの可能性がある

#### 修正方法
-  `_form.html`で`<%= f.fields_for :post_images do |post_image_form| %>`を1つに減らす（4→1）
- `postscontroller`の`new｀アクションで`4.times { @post.post_images.build }`を使用することで、4つの投稿
　

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- 

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
