### PR TITLE
追加：YouTube共有URL添付機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,7 +58,13 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :body, :image, post_images_attributes: %i[id image caption _destroy])
+    params.require(:post).permit(
+      :title,
+      :body,
+      :image,
+      post_images_attributes: %i[id image caption ],
+      post_videos_attributes: %i[id youtube_url caption ]
+    )
   end
 
   def set_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,12 +16,14 @@ class PostsController < ApplicationController
   def new
     @post = Post.new
     4.times { @post.post_images.build } # 4つの空のフォームを作成
+    4.times { @post.post_videos.build }
   end
 
   def edit
     # 常に4つのフォームを表示するため、不足分のオブジェクトを追加
     # 既存の画像,説明文がある場合はそれを保持し、合計が4つになるように
     (4 - @post.post_images.size).times { @post.post_images.build }
+    (4 - @post.post_videos.size).times { @post.post_videos.build }
   end
 
   def create
@@ -33,6 +35,7 @@ class PostsController < ApplicationController
       # バリデーション失敗時、常に4つのフォームを表示するため不足分を追加
       # 送信されたデータは保持しつつ、合計が4つになるように
       (4 - @post.post_images.size).times { @post.post_images.build }
+      (4 - @post.post_videos.size).times { @post.post_videos.build }
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
@@ -44,6 +47,7 @@ class PostsController < ApplicationController
       redirect_to post_path(@post)
     else
       (4 - @post.post_images.size).times { @post.post_images.build }
+      (4 - @post.post_videos.size).times { @post.post_videos.build }
       flash.now[:alert] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,15 +15,11 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
-    4.times { @post.post_images.build } # 4つの空のフォームを作成
-    4.times { @post.post_videos.build }
+    prepare_nested_forms
   end
 
   def edit
-    # 常に4つのフォームを表示するため、不足分のオブジェクトを追加
-    # 既存の画像,説明文がある場合はそれを保持し、合計が4つになるように
-    (4 - @post.post_images.size).times { @post.post_images.build }
-    (4 - @post.post_videos.size).times { @post.post_videos.build }
+    prepare_nested_forms
   end
 
   def create
@@ -32,10 +28,7 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human)
       redirect_to posts_path
     else
-      # バリデーション失敗時、常に4つのフォームを表示するため不足分を追加
-      # 送信されたデータは保持しつつ、合計が4つになるように
-      (4 - @post.post_images.size).times { @post.post_images.build }
-      (4 - @post.post_videos.size).times { @post.post_videos.build }
+      prepare_nested_forms
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
@@ -46,8 +39,7 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.updated', item: Post.model_name.human)
       redirect_to post_path(@post)
     else
-      (4 - @post.post_images.size).times { @post.post_images.build }
-      (4 - @post.post_videos.size).times { @post.post_videos.build }
+      prepare_nested_forms
       flash.now[:alert] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end
@@ -66,13 +58,25 @@ class PostsController < ApplicationController
       :title,
       :body,
       :image,
-      post_images_attributes: %i[id image caption ],
-      post_videos_attributes: %i[id youtube_url caption ]
+      post_images_attributes: %i[id image caption],
+      post_videos_attributes: %i[id youtube_url caption]
     )
   end
 
   def set_post
     @post = current_user.posts.find(params[:id])
+  end
+
+  # サブ画像、youtubeリンクのフォームを生成する
+  def prepare_nested_forms
+    ensure_nested_form_items(@post.post_images)
+    ensure_nested_form_items(@post.post_videos)
+  end
+
+  # 常に4つのフォームを表示するため、不足分のオブジェクトを追加
+  # 既存の入力があれば保持し、合計が4つになるようにbuild
+  def ensure_nested_form_items(association, count = 4)
+    (count - association.size).times { association.build }
   end
 
   def prepare_meta_tags(post)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,8 @@ class Post < ApplicationRecord
   has_many :notifications, as: :notifiable, dependent: :destroy
   has_many :post_images, dependent: :destroy
   accepts_nested_attributes_for :post_images, allow_destroy: true, reject_if: :all_blank
+  has_many :post_videos, dependent: :destroy
+  accepts_nested_attributes_for :post_videos, allow_destroy: true, reject_if: :all_blank
 
   mount_uploader :image, ImageUploader
 

--- a/app/models/post_video.rb
+++ b/app/models/post_video.rb
@@ -5,7 +5,6 @@ class PostVideo < ApplicationRecord
 
 
   def split_id_from_youtube_url
-    # YoutubeならIDのみ抽出
-    youtube_url.split('/').last
+    self.youtube_url = youtube_url.split('/').last
   end
 end

--- a/app/models/post_video.rb
+++ b/app/models/post_video.rb
@@ -1,0 +1,3 @@
+class PostVideo < ApplicationRecord
+  
+end

--- a/app/models/post_video.rb
+++ b/app/models/post_video.rb
@@ -1,3 +1,11 @@
 class PostVideo < ApplicationRecord
   belongs_to :post
+
+  before_save :split_id_from_youtube_url
+
+
+  def split_id_from_youtube_url
+    # YoutubeならIDのみ抽出
+    youtube_url.split('/').last
+  end
 end

--- a/app/models/post_video.rb
+++ b/app/models/post_video.rb
@@ -1,3 +1,3 @@
 class PostVideo < ApplicationRecord
-  
+  belongs_to :post
 end

--- a/app/models/post_video.rb
+++ b/app/models/post_video.rb
@@ -3,7 +3,6 @@ class PostVideo < ApplicationRecord
 
   before_save :split_id_from_youtube_url
 
-
   def split_id_from_youtube_url
     self.youtube_url = youtube_url.split('/').last
   end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -27,8 +27,22 @@
       </div>
     <% end %>
   </div>
+  <div>
+    <%= f.fields_for :post_videos do |post_video_form| %>
+      <div class="mb-4">
+        <%= post_video_form.label :youtube_url, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_video_form.text_field :youtube_url,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+      <div class="mb-4">
+        <%= post_video_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+        <%= post_video_form.text_field :caption,
+                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      </div>
+    <% end %>
+  </div>
   <!-- 投稿ボタン -->
   <div class="flex justify-center">
-  <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>
+    <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>
   </div>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -44,6 +44,9 @@
               allow: 'encrypted-media',
               allowfullscreen: true,
               class: 'w-full' %>
+          <% if post_video.caption.present? %>
+            <p class="mb-4 text-center"><%= post_video.caption %></p>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -29,6 +29,27 @@
     </div>
   <% end %>
 
+  <!-- youtube埋め込み -->
+  <% if @post.post_videos.present? %>
+  <div class="my-6">
+    <% @post.post_videos.each do |post_video| %>
+      <div class="flex justify-center mb-4">
+        <div class="w-full max-w-xl">
+          <%= content_tag 'iframe', nil,
+              width: '100%',
+              height: '315',
+              src: "https://www.youtube.com/embed/#{post_video.youtube_url}",
+              frameborder: '0',
+              gesture: 'media',
+              allow: 'encrypted-media',
+              allowfullscreen: true,
+              class: 'w-full' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
   <!-- Xシェアボタン -->
   <div class="flex justify-center my-6">
     <% encode_text = URI.encode_www_form_component("【KORESUKI】\nわたしの好き「#{@post.title}」を投稿しました！") %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -36,14 +36,14 @@
       <div class="flex justify-center mb-4">
         <div class="w-full max-w-xl">
           <%= content_tag 'iframe', nil,
-              width: '100%',
-              height: '315',
-              src: "https://www.youtube.com/embed/#{post_video.youtube_url}",
-              frameborder: '0',
-              gesture: 'media',
-              allow: 'encrypted-media',
-              allowfullscreen: true,
-              class: 'w-full' %>
+                          width: '100%',
+                          height: '315',
+                          src: "https://www.youtube.com/embed/#{post_video.youtube_url}",
+                          frameborder: '0',
+                          gesture: 'media',
+                          allow: 'encrypted-media',
+                          allowfullscreen: true,
+                          class: 'w-full' %>
           <% if post_video.caption.present? %>
             <p class="mb-4 text-center"><%= post_video.caption %></p>
           <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -17,4 +17,7 @@ ja:
       post_image:
         image: サブ画像
         caption: サブ画像の説明文
+      post_video:
+        youtube_url: YouTube共有URL（YouTube動画の共有ボタンからコピーしたURLを入力してください）
+        caption: YouTube動画の説明文
     # errors.models: バリデーションエラー

--- a/db/migrate/20250227155733_create_post_videos.rb
+++ b/db/migrate/20250227155733_create_post_videos.rb
@@ -1,0 +1,11 @@
+class CreatePostVideos < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_videos, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.references :post, null: false, foreign_key: true, type: :uuid
+      t.string :youtube_url
+      t.text :caption
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_26_051325) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_27_155733) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "comments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.text "content", null: false
+    t.text "body", null: false
     t.uuid "user_id", null: false
     t.uuid "post_id", null: false
     t.datetime "created_at", null: false
@@ -59,6 +59,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_26_051325) do
     t.index ["post_id"], name: "index_post_images_on_post_id"
   end
 
+  create_table "post_videos", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "post_id", null: false
+    t.string "youtube_url"
+    t.text "caption"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_post_videos_on_post_id"
+  end
+
   create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.string "title", null: false
@@ -92,5 +101,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_26_051325) do
   add_foreign_key "notifications", "users", column: "visited_id"
   add_foreign_key "notifications", "users", column: "visitor_id"
   add_foreign_key "post_images", "posts"
+  add_foreign_key "post_videos", "posts"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## issue番号
closes #88 
closes #89 
## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿にYoutube共有URLを添付して、Youtubeを埋め込みできる機能を実装
## やったこと
<!-- このプルリクで何をしたのか？ -->
- `Postvideos`テーブル作成（カラム 　`youtube_url（string）`、`caption（text）`）
- モデル関連付け実施（`post`モデルと一対多,`accepts_nested_attributes_for`）
- `before_save`コールバック定義
　- フォームから入力された`youtube_url`を、保存される前に実行する`split_id_from_youtube_url`定義
　- `params`の`youtube_url`を`/`で区切って、最後の文字列だけを取得する
- コントローラーで`post_params`を許可
- `posts`コントーラー編集
　- 投稿フォームロジックはサブ画像投稿の同様の実装
　- 共通ロジックのため`private`、`prepare_nested_forms`に定義する
　- 常に4つの`post_videos`オブジェクトを`build`する、`else`の場合は、最大4つになるように`build`する
- 投稿フォーム、投稿詳細view編集
- lint修正実施
## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- Youtube動画を投稿に添付できるようになる（現時点では4つまで）

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
-  `before_save`コールバックの挙動確認
- 入力値　`https://youtu.be/v469x9n8c8k?si=6rq6s7JHBIEJ2K_u`
- 保存値　`v469x9n8c8k?si=6rq6s7JHBIEJ2K_u`
[![Image from Gyazo](https://i.gyazo.com/b5531b45cc10135dc168400348425805.png)](https://gyazo.com/b5531b45cc10135dc168400348425805)
- 投稿作成、編集、更新、削除の挙動確認

## その他
<!-- レビュワーへの参考情報 -->
- サブ画像同様、最大4つの投稿フォームを作成
- 今後、動的に投稿フォームを追加できるようにしたい、別isseuで対応する

## 関連Issue
<!-- このPRが関連するIssue -->
- なし