### PR TITLE
追加：gem_draper,bulletインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,9 @@ group :development do
 
   gem 'letter_opener_web'
 
+  gem "better_errors"
+  gem "binding_of_caller"
+
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ group :development do
   gem "better_errors"
   gem "binding_of_caller"
 
+  gem 'bullet'
+
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,9 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bullet (8.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -390,6 +393,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -421,6 +425,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
+  bullet
   capybara
   carrierwave (~> 3.0)
   cssbundling-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,10 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
+    better_errors (2.10.1)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+      rouge (>= 1.0.0)
     better_html (2.1.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -97,6 +101,8 @@ GEM
       smart_properties
     bigdecimal (3.1.9)
     bindex (0.8.1)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
@@ -127,6 +133,7 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    debug_inspector (1.2.0)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -325,6 +332,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.0)
+    rouge (4.5.1)
     rubocop (1.71.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -410,6 +418,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bootsnap
   capybara
   carrierwave (~> 3.0)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,8 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[edit update destroy]
 
   def index
-    @posts = Post.includes(:user, :likes).order(created_at: :desc)
+    @posts = Post.includes(:user).order(created_at: :desc)
+    @current_user_likes = current_user.likes.where(likeable_type: 'Post').index_by(&:likeable_id)
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[edit update destroy]
 
   def index
-    @posts = Post.includes(:user, :likes)
+    @posts = Post.includes(:user, :likes).order(created_at: :desc)
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,4 @@ class User < ApplicationRecord
     likes.find_by(likeable: likeable)&.destroy
   end
 
-  def like?(likeable)
-    likes.exists?(likeable: likeable)
-  end
 end

--- a/app/views/likes/_like_buttons.html.erb
+++ b/app/views/likes/_like_buttons.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
   <div class='ms-auto'>
-    <% if current_user.like?(likeable) %>
+    <% if @current_user_likes && @current_user_likes[likeable.id].present? %>
       <%= render 'likes/unlike_button', { likeable: likeable } %>
     <% else %>
       <%= render 'likes/like_button', { likeable: likeable } %>

--- a/app/views/likes/_unlike_button.html.erb
+++ b/app/views/likes/_unlike_button.html.erb
@@ -1,4 +1,5 @@
-<% like = current_user.likes.find_by(likeable: likeable) %>
+
+<% like = @current_user_likes[likeable.id] %>
 <!-- destoryなので、like_idも渡す -->
 <%= link_to like_path(id: like.id, likeable_type: likeable.class.name, likeable_id: likeable.id), id: "unlike-button-#{likeable.id}",
                                                                                                   data: { turbo_method: :delete }, class: 'btn btn-ghost' do %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with mode, class: 'space-y-4' do |f| %>
+<%= form_with model: @post, class: 'space-y-4' do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div>
     <%= f.label :title, class: 'block text-sm font-medium text-gray-700' %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @post, class: 'space-y-4' do |f| %>
+<%= form_with mode, class: 'space-y-4' do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div>
     <%= f.label :title, class: 'block text-sm font-medium text-gray-700' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,4 +79,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
+
 end


### PR DESCRIPTION
## issue番号
close #93 
## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- gem_draperインストールして、エラー画面の表示を変更
- gem_bulletインストールして、n+1問題を検出、修正

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 上記gemインストール実施
- 投稿一覧のn+1問題修正
　-  投稿一覧のいいねの表示でn+1問題が発生していた
　- 原因 `postscontroller`の`index`アクションで`like`も`include`していたが、viewの`like`?メソッドで各投稿毎に`exits`していてたため、追加クエリが発生していた
　- 対処法 `postscontroller`で`.index_by(&:likeable_id)`でidをキーにハッシュ化していいねオブジェクトを一括取得
　- viewではpresent?で判定をおこないクエリの発行を行わないようにする
## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- n+1問題修正のため、投稿一覧の読み込みがスムーズになる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- エラー発生時の表示変更確認
- ログをみて、発行クエリの減少確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
