### PR TITLE
fix:ログイン前の投稿一覧が表示されない、Xシェアが反映されない

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,11 +4,12 @@ class PostsController < ApplicationController
 
   def index
     @posts = Post.includes(:user).order(created_at: :desc)
-    @current_user_likes = current_user.likes.where(likeable_type: 'Post').index_by(&:likeable_id)
+    @current_user_likes = current_user&.likes&.where(likeable_type: 'Post')&.index_by(&:likeable_id) || {}
   end
 
   def show
     @post = Post.find(params[:id])
+    prepare_meta_tags(@post)
     @comment = Comment.new
     @comments = @post.comments.includes(:user).order(created_at: :desc)
   end

--- a/app/views/staticpages/top.html.erb
+++ b/app/views/staticpages/top.html.erb
@@ -2,6 +2,8 @@
     Hello world!
 </h1>
 
+<%= link_to t('header.all_suki'), posts_path, class: 'px-4 py-2' %>
+
 <button class="bg-gray-900 hover:bg-gray-800 text-white rounded px-4 py-2">tailwind</button>
 
 <button class="btn">daisyUI</button>


### PR DESCRIPTION
## issue番号
## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 1 ログイン前の投稿一覧が表示されない
- 2 ログイン前の投稿一覧が表示されない、Xシェアが反映されないを修正

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 1 原因
`@current_user_likes = current_user.likes.where(likeable_type: 'Post').index_by(&:likeable_id)`で`cureent_user`を使用していため、ノーメソッドになりエラーが起きる
- 1 対応　
`current_user&.likes&.where(likeable_type: 'Post')&.index_by(&:likeable_id) || {}`
`&`を使用してnilの場合は次のメソッドをスキップ、`||{}`で空のハッシュを返す
- 2 原因 `show`アクションで`prepare_meta_tags(@post)`の記載忘れ
- 2 対応  `show`アクションで`prepare_meta_tags(@post)`の記載
- トップページに投稿一覧への動線確保

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- ログイン前に投稿一覧を見れる
- ログイン前にトップページから投稿一覧へ遷移できる
- xシェアできる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで挙動の確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
