### PR TITLE
add：メイン画像が未設定の場合、youtubeのサムネイルを投稿一覧に表示

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[edit update destroy]
 
   def index
-    @posts = Post.includes(:user).order(created_at: :desc)
+    @posts = Post.includes(:user, :post_videos).order(created_at: :desc)
     @current_user_likes = current_user.present? ? current_user.likes.where(likeable_type: 'Post').index_by(&:likeable_id) : {}
   end
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -19,7 +19,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   process :convert_heic_to_jpg, if: :heic?
 
   version :mini do
-    process resize_to_fill: [400, 350]
+    process resize_to_fill: [400, 300]
     process :convert_heic_to_jpg, if: :heic?
   end
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -9,10 +9,17 @@
         <%= link_to post.title, post_path(post) %>
       </h4>
     </div>
-
     <div class="mt-3">
       <% if post.image.present? %>
         <%= image_tag post.image.mini.url, class: ' object-cover rounded-lg' %>
+      <% elsif post.post_videos.present? %>
+        <div class="w-full aspect-video">
+          <%= image_tag "https://img.youtube.com/vi/#{post.post_videos.first.youtube_url.to_s[0..10]}/hqdefault.jpg",
+               width: '100%',
+               height: '100%',
+               class: 'rounded-lg',
+               alt: "YouTube動画のサムネイル" %>
+        </div>
       <% else %>
         <div class="w-full h-48 bg-gray-300 flex items-center justify-center rounded-lg">
           <span class="text-gray-600 text-lg">写真</span>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -15,10 +15,10 @@
       <% elsif post.post_videos.present? %>
         <div class="w-full aspect-video">
           <%= image_tag "https://img.youtube.com/vi/#{post.post_videos.first.youtube_url.to_s[0..10]}/hqdefault.jpg",
-               width: '100%',
-               height: '100%',
-               class: 'rounded-lg',
-               alt: "YouTube動画のサムネイル" %>
+                        width: '100%',
+                        height: '100%',
+                        class: 'rounded-lg',
+                        alt: 'YouTube動画のサムネイル' %>
         </div>
       <% else %>
         <div class="w-full h-48 bg-gray-300 flex items-center justify-center rounded-lg">


### PR DESCRIPTION
## issue番号
close #98 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 追加前　投稿のメイン画像が未設定の場合、投稿一覧の画像は「画像なし」と表示
- 追加後　投稿のメイン画像が未設定の場合かつ、youtubeurlを投稿していた場合、youtubeの一番上のサムネイルを投稿一覧の画像に表示

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `_post.html.erb`でyoutubeのサムネイルを取得して、表示
- `image_uploader.rb`でサムネイルの画像サイズに合わせて、メイン画像のリサイズ調整[400.350]👉[400.300]

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- 投稿のメイン画像が未設定の場合かつ、youtubeurlを投稿していない場合の表示は現状のまま

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 投稿のメイン画像が未設定の場合かつ、youtubeurlを投稿していた場合、youtubeの一番上のサムネイルを投稿一覧の画像に表示する
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで挙動を確認
- 左　メイン画像リサイズ後[400.300]
- 中　youtubeサムネイル
- 右　メイン画像リサイズ前[400.350]
[![Image from Gyazo](https://i.gyazo.com/5f35c42dc7f929d3d0d71b72194a01d9.jpg)](https://gyazo.com/5f35c42dc7f929d3d0d71b72194a01d9)

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
