### PR TITLE
fix：デプロイエラー

### DIFF
--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,4 +1,1 @@
-if defined?(Bullet)
-	Bullet.add_safelist type: :unused_eager_loading, class_name: 'Notification', association: :visitor
-end
-  
+Bullet.add_safelist type: :unused_eager_loading, class_name: 'Notification', association: :visitor if defined?(Bullet)

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,1 +1,4 @@
-Bullet.add_safelist type: :unused_eager_loading, class_name: 'Notification', association: :visitor
+if defined?(Bullet)
+	Bullet.add_safelist type: :unused_eager_loading, class_name: 'Notification', association: :visitor
+end
+  


### PR DESCRIPTION
## issue番号


## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- デプロイエラーのため修正
  - 予想する原因
  - gem bulletは開発環境にのみ導入していたため、本番環境で`config/initializers/bullet.rb`を読み込む時にエラー
  - エラーログ
[![Image from Gyazo](https://i.gyazo.com/ab595fa85be958a00629e275a714f24c.png)](https://gyazo.com/ab595fa85be958a00629e275a714f24c)

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `config/initializers/bullet.rb` 修正
  - `defined?`を使用してbulletが定義されているかチェック

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- なし

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし
