### PR TITLE
fix：通知機能修正（最新版）

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,16 +9,16 @@ class Comment < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: 300 }
 
-
-  #　呼び出される時
+  # 　呼び出される時
   # 1コメントに対していいね作成時 2コメント作成時（else)
   def create_notification(visitor, action)
     if action == :liked
       # いいねした人とコメント作成者が同じ場合は通知しない
       return if visitor.id == user.id
+
       # 同じコメントに繰り返しいいねの通知を防ぐため、find_or_initialize_by
       notification = Notification.find_or_initialize_by(
-        visitor_id: visitor.id  # current_user
+        visitor_id: visitor.id, # current_user
         visited_id: user.id, # コメント作成者
         notifiable: self, # 通知元、like
         action: action # liked
@@ -27,7 +27,7 @@ class Comment < ApplicationRecord
     else # コメント作成時
       # コメントしたユーザーと投稿作成者が同じ場合は通知を作成しない
       return if visitor.id == post.user.id
-      
+
       Notification.create!(
         visitor_id: visitor.id, # current_user
         visited_id: post.user.id, # 投稿作成者
@@ -37,4 +37,3 @@ class Comment < ApplicationRecord
     end
   end
 end
-

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,19 +9,32 @@ class Comment < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: 300 }
 
-  def create_notification(visitor, action)
-    # いいねユーザーとコメント作成者が同じ場合は通知を作成しない
-    return if visitor.id == user.id
 
-    Notification.create!(
-      # current_userが入る
-      visitor_id: visitor.id,
-      # コメントしたユーザー
-      visited_id: user.id,
-      # 通知の対象、コメントが入る
-      notifiable: self,
-      # いいねが入る
-      action: action
-    )
+  #　呼び出される時
+  # 1コメントに対していいね作成時 2コメント作成時（else)
+  def create_notification(visitor, action)
+    if action == :liked
+      # いいねした人とコメント作成者が同じ場合は通知しない
+      return if visitor.id == user.id
+      # 同じコメントに繰り返しいいねの通知を防ぐため、find_or_initialize_by
+      notification = Notification.find_or_initialize_by(
+        visitor_id: visitor.id  # current_user
+        visited_id: user.id, # コメント作成者
+        notifiable: self, # 通知元、like
+        action: action # liked
+      )
+      notification.save
+    else # コメント作成時
+      # コメントしたユーザーと投稿作成者が同じ場合は通知を作成しない
+      return if visitor.id == post.user.id
+      
+      Notification.create!(
+        visitor_id: visitor.id, # current_user
+        visited_id: post.user.id, # 投稿作成者
+        notifiable: self, # 通知元、comment
+        action: action # commented
+      )
+    end
   end
 end
+

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -18,6 +18,7 @@ class Post < ApplicationRecord
   def create_notification(visitor, action)
     # いいねしたユーザーと投稿者が同じ場合は通知を作成しない
     return if visitor.id == user.id
+
     # find_or_initialize_by　既存のレコードを取得,存在しない場合は新しく作成
     # いいねを複数回押しても1回分の通知しか作成されないように
     notification = Notification.find_or_initialize_by(

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,21 +14,17 @@ class Post < ApplicationRecord
   validates :title, presence: true
   validates :body, presence: true
 
+  # 投稿にいいね作成時呼び出し
   def create_notification(visitor, action)
-    # いいね、コメントしたユーザーと投稿者が同じ場合は通知を作成しない
+    # いいねしたユーザーと投稿者が同じ場合は通知を作成しない
     return if visitor.id == user.id
-
     # find_or_initialize_by　既存のレコードを取得,存在しない場合は新しく作成
     # いいねを複数回押しても1回分の通知しか作成されないように
     notification = Notification.find_or_initialize_by(
-      # current_userが入る
-      visitor_id: visitor.id,
-      # 投稿者が入る
-      visited_id: user.id,
-      # 通知の対象、ポストが入る
-      notifiable: self,
-      # いいね、コメントが入る
-      action: action
+      visitor_id: visitor.id, # current_user
+      visited_id: user.id, # 投稿者
+      notifiable: self, # 通知元、like
+      action: action # liked
     )
 
     notification.save


### PR DESCRIPTION
## issue番号


## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 通知機能で複数のエラーが発生していたため、コードの見直しを実施
- `Comment` および `Post` モデルの `create_notification` メソッドを見直し、修正

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `Comment` モデルと `Post` モデルの `create_notification` メソッドのコード改善
- 処理内容を明確にするためのコメント追加

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->

### 通知機能の改善

#### コメントへのいいね通知（app/models/comment.rb）
- 自分自身のコメントにいいねした場合は通知を作成しない
- 同じユーザーが同じコメントに複数回いいねした場合でも、通知は1回のみ作成（`find_or_initialize_by` を使用）
- コメント作成者に対して「〜さんがあなたのコメントにいいねしました」という通知を作成

#### 投稿へのコメント通知（app/models/comment.rb）
- 自分自身の投稿にコメントした場合は通知を作成しない
- 投稿作成者に対して「〜さんがあなたの投稿にコメントしました」という通知を作成

#### 投稿へのいいね通知（app/models/post.rb）
- 自分自身の投稿にいいねした場合は通知を作成しない
- 同じユーザーが同じ投稿に複数回いいねした場合でも、通知は1回のみ作成（`find_or_initialize_by` を使用）
- 投稿作成者に対して「〜さんがあなたの投稿にいいねしました」という通知を作成

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- 上記通知条件をローカルでテストし、正常に通知が作成されることを確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->

