### PR TITLE
add：サブ画像、youtubeURL投稿フォームを動的に追加可能に

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,12 +17,10 @@ class PostsController < ApplicationController
   end
 
   def new
-    @post = Post.new.decorate
-    @post.prepare_nested_forms
+    @post = Post.new
   end
 
   def edit
-    @post.prepare_nested_forms
   end
 
   def create
@@ -31,8 +29,7 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human)
       redirect_to posts_path
     else
-      @post = @post.decorate
-      @post.prepare_nested_forms
+      @post = @post
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
@@ -43,7 +40,6 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.updated', item: Post.model_name.human)
       redirect_to post_path(@post)
     else
-      @post.prepare_nested_forms
       flash.now[:alert] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end
@@ -72,7 +68,7 @@ class PostsController < ApplicationController
   end
 
   def set_post
-    @post = current_user.posts.find(params[:id]).decorate
+    @post = current_user.posts.find(params[:id])
   end
 
   def prepare_meta_tags(post)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -66,8 +66,8 @@ class PostsController < ApplicationController
       :title,
       :body,
       :image,
-      post_images_attributes: %i[id image caption],
-      post_videos_attributes: %i[id youtube_url caption]
+      post_images_attributes: [:id, :image, :caption, :_destroy],
+      post_videos_attributes: [:id, :youtube_url, :caption, :_destroy]
     )
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,8 +20,7 @@ class PostsController < ApplicationController
     @post = Post.new
   end
 
-  def edit
-  end
+  def edit; end
 
   def create
     @post = current_user.posts.build(post_params)
@@ -29,7 +28,6 @@ class PostsController < ApplicationController
       flash[:notice] = t('defaults.flash_message.created', item: Post.model_name.human)
       redirect_to posts_path
     else
-      @post = @post
       flash.now[:alert] = t('defaults.flash_message.not_created', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
@@ -62,8 +60,8 @@ class PostsController < ApplicationController
       :title,
       :body,
       :image,
-      post_images_attributes: [:id, :image, :caption, :_destroy],
-      post_videos_attributes: [:id, :youtube_url, :caption, :_destroy]
+      post_images_attributes: %i[id image caption _destroy],
+      post_videos_attributes: %i[id youtube_url caption _destroy]
     )
   end
 

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -1,15 +1,16 @@
 class PostDecorator < Draper::Decorator
   delegate_all
 
+  # ビューでNewするため、コントローラーでのbuildは不要に
   # サブ画像、youtubeリンクの投稿フォームを生成する
-  def prepare_nested_forms
-    ensure_nested_form_items(object.post_images)
-    ensure_nested_form_items(object.post_videos)
-  end
+  # def prepare_nested_forms
+  #   ensure_nested_form_items(object.post_images)
+  #   ensure_nested_form_items(object.post_videos)
+  # end
 
   # 常に4つのフォームを表示するため、不足分のオブジェクトを追加
   # 既存の入力があれば保持し、合計が指定数になるようにbuild
-  def ensure_nested_form_items(association, count = 0)
-    (count - association.size).times { association.build }
-  end
+  # def ensure_nested_form_items(association, count = 4)
+  #   (count - association.size).times { association.build }
+  # end
 end

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -8,8 +8,8 @@ class PostDecorator < Draper::Decorator
   end
 
   # 常に4つのフォームを表示するため、不足分のオブジェクトを追加
-  # 既存の入力があれば保持し、合計が4つになるようにbuild
-  def ensure_nested_form_items(association, count = 4)
+  # 既存の入力があれば保持し、合計が指定数になるようにbuild
+  def ensure_nested_form_items(association, count = 0)
     (count - association.size).times { association.build }
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import NestedFormController from "./nested_form_controller"
+application.register("nested-form", NestedFormController)

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="nested-form"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,7 +1,39 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="nested-form"
 export default class extends Controller {
+  static targets = ["template", "container"]
+  
   connect() {
+    console.log("Nested form controller connected")
+  }
+  
+  add(event) {
+    event.preventDefault()
+    
+    // 親要素のdata-nested-form-target属性を取得
+    const containerType = event.currentTarget.dataset.type
+    const template = this.templateTargets.find(t => t.dataset.type === containerType)
+    const container = this.containerTargets.find(c => c.dataset.type === containerType)
+    
+    // テンプレートからHTMLを取得し、一意のIDを生成して置換
+    const content = template.innerHTML.replace(/NEW_RECORD/g, new Date().getTime())
+    
+    // フォームコンテナに追加
+    container.insertAdjacentHTML('beforeend', content)
+  }
+  
+  remove(event) {
+    event.preventDefault()
+    
+    const wrapper = event.target.closest('.nested-form-wrapper')
+    
+    // hidden _destroy フィールドがある場合（既存レコード）
+    if (wrapper.querySelector("input[name*='_destroy']")) {
+      wrapper.querySelector("input[name*='_destroy']").value = 1
+      wrapper.style.display = 'none'
+    } else {
+      // 新規追加したフォームの場合は単にDOM削除
+      wrapper.remove()
+    }
   }
 }

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -3,34 +3,35 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["template", "container"]
   
-  // コントローラーが呼ばれたら実行される railsでいうと before_action,initialize
+  // ログに出力
   connect() {
     console.log("Nested form controller connected")
   }
   
-  // addメソッド　追加ボタン
   add(event) {
-    event.preventDefault() // Railsでいうと remote: true
+    event.preventDefault()
     
-    // 親要素のdata-nested-form-target属性を取得
+    // data-type 属性から取得
     const containerType = event.currentTarget.dataset.type
+    // templateを取得
     const template = this.templateTargets.find(t => t.dataset.type === containerType)
+    // 追加先のcontainerを取得
     const container = this.containerTargets.find(c => c.dataset.type === containerType)
     
     // テンプレートからHTMLを取得し、一意のIDを生成して置換
     const content = template.innerHTML.replace(/NEW_RECORD/g, new Date().getTime())
     
-    // フォームコンテナに追加
+    // フォームコンテナの一番下に追加
     container.insertAdjacentHTML('beforeend', content)
   }
   
-  // removeメソッド 削除ボタン
   remove(event) {
-    event.preventDefault() // Railsでいうと remote: true
+    event.preventDefault()
     
+    // 削除対象のフォームを取得
     const wrapper = event.target.closest('.nested-form-wrapper')
     
-    // hidden _destroy フィールドがある場合（既存レコード）
+    // 既存レコードがある場合、hidden _destroyを1にする
     if (wrapper.querySelector("input[name*='_destroy']")) {
       wrapper.querySelector("input[name*='_destroy']").value = 1
       wrapper.style.display = 'none'

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -3,12 +3,14 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["template", "container"]
   
+  // コントローラーが呼ばれたら実行される railsでいうと before_action,initialize
   connect() {
     console.log("Nested form controller connected")
   }
   
+  // addメソッド　追加ボタン
   add(event) {
-    event.preventDefault()
+    event.preventDefault() // Railsでいうと remote: true
     
     // 親要素のdata-nested-form-target属性を取得
     const containerType = event.currentTarget.dataset.type
@@ -22,8 +24,9 @@ export default class extends Controller {
     container.insertAdjacentHTML('beforeend', content)
   }
   
+  // removeメソッド 削除ボタン
   remove(event) {
-    event.preventDefault()
+    event.preventDefault() // Railsでいうと remote: true
     
     const wrapper = event.target.closest('.nested-form-wrapper')
     

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -31,6 +31,7 @@
               <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
               <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
             </div>
+            <!-- 削除ボタン -->
             <div class="text-right">
               <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
             </div>
@@ -55,6 +56,7 @@
               <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
               <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
             </div>
+            <!-- 削除ボタン -->
             <div class="text-right">
               <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
             </div>
@@ -86,6 +88,7 @@
               <%= post_video_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
               <%= post_video_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
             </div>
+            <!-- 削除ボタン -->
             <div class="text-right">
               <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
             </div>
@@ -110,6 +113,7 @@
               <%= post_video_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
               <%= post_video_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
             </div>
+            <!-- 削除ボタン -->
             <div class="text-right">
               <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
             </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -27,6 +27,7 @@
       </div>
     <% end %>
   </div>
+  <!-- youtube -->
   <div>
     <%= f.fields_for :post_videos do |post_video_form| %>
       <div class="mb-4">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -17,7 +17,7 @@
   <div data-controller="nested-form">
       <!-- サブ画像 -->
     <div class="mb-6">
-      <h3 class="font-medium text-lg mb-2">サブ画像</h3>
+      <h3 class="font-medium text-lg mb-2"><%= t('.post_images')%></h3>
       <!-- テンプレート - 新規追加用 -->
       <template data-nested-form-target="template" data-type="post_images">
         <div class="nested-form-wrapper border p-4 rounded-md mb-4">
@@ -40,14 +40,14 @@
       </div>
       <div class="mt-2">
         <button data-action="nested-form#add" data-type="post_images" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md">
-          サブ画像を追加
+          <%= t('helpers.submit.addition') %>
         </button>
       </div>
     </div>
 
     <!-- YouTube動画 -->
     <div class="mb-6">
-      <h3 class="font-medium text-lg mb-2">YouTube動画</h3>
+      <h3 class="font-medium text-lg mb-2"><%= t('.post_videos')%></h3>
       <!-- テンプレート - 新規追加用 -->
       <template data-nested-form-target="template" data-type="post_videos">
         <div class="nested-form-wrapper border p-4 rounded-md mb-4">
@@ -70,7 +70,7 @@
       </div>
       <div class="mt-2">
         <button data-action="nested-form#add" data-type="post_videos" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md">
-          YouTube動画を追加
+          <%= t('helpers.submit.addition') %>
         </button>
       </div>
     </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -17,7 +17,7 @@
   <div data-controller="nested-form">
       <!-- サブ画像 -->
     <div class="mb-6">
-      <h3 class="font-medium text-lg mb-2"><%= t('.post_images')%></h3>
+      <h3 class="font-medium text-lg mb-2"><%= t('.post_images') %></h3>
       <!-- テンプレート - 新規追加用 -->
       <template data-nested-form-target="template" data-type="post_images">
         <div class="nested-form-wrapper border p-4 rounded-md mb-4">
@@ -47,7 +47,7 @@
 
     <!-- YouTube動画 -->
     <div class="mb-6">
-      <h3 class="font-medium text-lg mb-2"><%= t('.post_videos')%></h3>
+      <h3 class="font-medium text-lg mb-2"><%= t('.post_videos') %></h3>
       <!-- テンプレート - 新規追加用 -->
       <template data-nested-form-target="template" data-type="post_videos">
         <div class="nested-form-wrapper border p-4 rounded-md mb-4">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,33 +12,20 @@
     <%= f.label :image, class: 'block text-sm font-medium text-gray-700' %>
     <%= f.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
   </div>
-  
+
   <!-- Stimulusコントローラーを適用 -->
   <div data-controller="nested-form">
-    <!-- サブ画像 -->
+      <!-- サブ画像 -->
     <div class="mb-6">
       <h3 class="font-medium text-lg mb-2">サブ画像</h3>
-      
       <!-- テンプレート - 新規追加用 -->
       <template data-nested-form-target="template" data-type="post_images">
         <div class="nested-form-wrapper border p-4 rounded-md mb-4">
           <%= f.fields_for :post_images, PostImage.new, child_index: 'NEW_RECORD' do |post_image_form| %>
-            <div class="mb-4">
-              <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-              <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-            </div>
-            <div class="mb-4">
-              <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-              <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-            </div>
-            <!-- 削除ボタン -->
-            <div class="text-right">
-              <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
-            </div>
+            <%= render 'post_image_fields', form: post_image_form %>
           <% end %>
         </div>
       </template>
-      
       <!-- 既存のフォームと新規追加されるフォームのコンテナ -->
       <div data-nested-form-target="container" data-type="post_images">
         <%= f.fields_for :post_images do |post_image_form| %>
@@ -47,55 +34,28 @@
             <% if post_image_form.object.persisted? %>
               <%= post_image_form.hidden_field :_destroy %>
             <% end %>
-            
-            <div class="mb-4">
-              <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-              <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-            </div>
-            <div class="mb-4">
-              <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-              <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-            </div>
-            <!-- 削除ボタン -->
-            <div class="text-right">
-              <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
-            </div>
+            <%= render 'post_image_fields', form: post_image_form %>
           </div>
         <% end %>
       </div>
-      
-      <!-- 追加ボタン -->
       <div class="mt-2">
         <button data-action="nested-form#add" data-type="post_images" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md">
           サブ画像を追加
         </button>
       </div>
     </div>
-  
+
     <!-- YouTube動画 -->
     <div class="mb-6">
       <h3 class="font-medium text-lg mb-2">YouTube動画</h3>
-      
       <!-- テンプレート - 新規追加用 -->
       <template data-nested-form-target="template" data-type="post_videos">
         <div class="nested-form-wrapper border p-4 rounded-md mb-4">
           <%= f.fields_for :post_videos, PostVideo.new, child_index: 'NEW_RECORD' do |post_video_form| %>
-            <div class="mb-4">
-              <%= post_video_form.label :youtube_url, class: 'block text-sm font-medium text-gray-700' %>
-              <%= post_video_form.text_field :youtube_url, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-            </div>
-            <div class="mb-4">
-              <%= post_video_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-              <%= post_video_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-            </div>
-            <!-- 削除ボタン -->
-            <div class="text-right">
-              <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
-            </div>
+          <%= render 'post_video_fields', form: post_video_form %>
           <% end %>
         </div>
       </template>
-      
       <!-- 既存のフォームと新規追加されるフォームのコンテナ -->
       <div data-nested-form-target="container" data-type="post_videos">
         <%= f.fields_for :post_videos do |post_video_form| %>
@@ -104,24 +64,10 @@
             <% if post_video_form.object.persisted? %>
               <%= post_video_form.hidden_field :_destroy %>
             <% end %>
-            
-            <div class="mb-4">
-              <%= post_video_form.label :youtube_url, class: 'block text-sm font-medium text-gray-700' %>
-              <%= post_video_form.text_field :youtube_url, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-            </div>
-            <div class="mb-4">
-              <%= post_video_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-              <%= post_video_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-            </div>
-            <!-- 削除ボタン -->
-            <div class="text-right">
-              <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
-            </div>
+            <%= render 'post_video_fields', form: post_video_form %>
           </div>
         <% end %>
       </div>
-      
-      <!-- 追加ボタン -->
       <div class="mt-2">
         <button data-action="nested-form#add" data-type="post_videos" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md">
           YouTube動画を追加
@@ -129,7 +75,7 @@
       </div>
     </div>
   </div>
-  
+
   <!-- 投稿ボタン -->
   <div class="flex justify-center">
     <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,36 +12,120 @@
     <%= f.label :image, class: 'block text-sm font-medium text-gray-700' %>
     <%= f.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
   </div>
-  <!-- サブ画像 -->
-  <div>
-    <%= f.fields_for :post_images do |post_image_form| %>
-      <div class="mb-4">
-        <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.file_field :image,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+  
+  <!-- Stimulusコントローラーを適用 -->
+  <div data-controller="nested-form">
+    <!-- サブ画像 -->
+    <div class="mb-6">
+      <h3 class="font-medium text-lg mb-2">サブ画像</h3>
+      
+      <!-- テンプレート - 新規追加用 -->
+      <template data-nested-form-target="template" data-type="post_images">
+        <div class="nested-form-wrapper border p-4 rounded-md mb-4">
+          <%= f.fields_for :post_images, PostImage.new, child_index: 'NEW_RECORD' do |post_image_form| %>
+            <div class="mb-4">
+              <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
+              <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+            </div>
+            <div class="mb-4">
+              <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+              <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+            </div>
+            <div class="text-right">
+              <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
+            </div>
+          <% end %>
+        </div>
+      </template>
+      
+      <!-- 既存のフォームと新規追加されるフォームのコンテナ -->
+      <div data-nested-form-target="container" data-type="post_images">
+        <%= f.fields_for :post_images do |post_image_form| %>
+          <div class="nested-form-wrapper border p-4 rounded-md mb-4">
+            <!-- 既存レコードの場合は_destroyフィールドを追加 -->
+            <% if post_image_form.object.persisted? %>
+              <%= post_image_form.hidden_field :_destroy %>
+            <% end %>
+            
+            <div class="mb-4">
+              <%= post_image_form.label :image, class: 'block text-sm font-medium text-gray-700' %>
+              <%= post_image_form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+            </div>
+            <div class="mb-4">
+              <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+              <%= post_image_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+            </div>
+            <div class="text-right">
+              <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
+            </div>
+          </div>
+        <% end %>
       </div>
-      <div class="mb-4">
-        <%= post_image_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_image_form.text_field :caption,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+      
+      <!-- 追加ボタン -->
+      <div class="mt-2">
+        <button data-action="nested-form#add" data-type="post_images" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md">
+          サブ画像を追加
+        </button>
       </div>
-    <% end %>
+    </div>
+  
+    <!-- YouTube動画 -->
+    <div class="mb-6">
+      <h3 class="font-medium text-lg mb-2">YouTube動画</h3>
+      
+      <!-- テンプレート - 新規追加用 -->
+      <template data-nested-form-target="template" data-type="post_videos">
+        <div class="nested-form-wrapper border p-4 rounded-md mb-4">
+          <%= f.fields_for :post_videos, PostVideo.new, child_index: 'NEW_RECORD' do |post_video_form| %>
+            <div class="mb-4">
+              <%= post_video_form.label :youtube_url, class: 'block text-sm font-medium text-gray-700' %>
+              <%= post_video_form.text_field :youtube_url, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+            </div>
+            <div class="mb-4">
+              <%= post_video_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+              <%= post_video_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+            </div>
+            <div class="text-right">
+              <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
+            </div>
+          <% end %>
+        </div>
+      </template>
+      
+      <!-- 既存のフォームと新規追加されるフォームのコンテナ -->
+      <div data-nested-form-target="container" data-type="post_videos">
+        <%= f.fields_for :post_videos do |post_video_form| %>
+          <div class="nested-form-wrapper border p-4 rounded-md mb-4">
+            <!-- 既存レコードの場合は_destroyフィールドを追加 -->
+            <% if post_video_form.object.persisted? %>
+              <%= post_video_form.hidden_field :_destroy %>
+            <% end %>
+            
+            <div class="mb-4">
+              <%= post_video_form.label :youtube_url, class: 'block text-sm font-medium text-gray-700' %>
+              <%= post_video_form.text_field :youtube_url, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+            </div>
+            <div class="mb-4">
+              <%= post_video_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+              <%= post_video_form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+            </div>
+            <div class="text-right">
+              <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      
+      <!-- 追加ボタン -->
+      <div class="mt-2">
+        <button data-action="nested-form#add" data-type="post_videos" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md">
+          YouTube動画を追加
+        </button>
+      </div>
+    </div>
   </div>
-  <!-- youtube -->
-  <div>
-    <%= f.fields_for :post_videos do |post_video_form| %>
-      <div class="mb-4">
-        <%= post_video_form.label :youtube_url, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_video_form.text_field :youtube_url,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-      </div>
-      <div class="mb-4">
-        <%= post_video_form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
-        <%= post_video_form.text_field :caption,
-                                       class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
-      </div>
-    <% end %>
-  </div>
+  
   <!-- 投稿ボタン -->
   <div class="flex justify-center">
     <%= f.submit t('helpers.submit.create'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>

--- a/app/views/posts/_post_image_fields.html.erb
+++ b/app/views/posts/_post_image_fields.html.erb
@@ -8,5 +8,5 @@
 </div>
 <!-- 削除ボタン -->
 <div class="text-right">
-  <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
+  <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md"><%= t('helpers.submit.delete') %></button>
 </div>

--- a/app/views/posts/_post_image_fields.html.erb
+++ b/app/views/posts/_post_image_fields.html.erb
@@ -1,0 +1,12 @@
+<div class="mb-4">
+  <%= form.label :image, class: 'block text-sm font-medium text-gray-700' %>
+  <%= form.file_field :image, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+</div>
+<div class="mb-4">
+  <%= form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+  <%= form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+</div>
+<!-- 削除ボタン -->
+<div class="text-right">
+  <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
+</div>

--- a/app/views/posts/_post_video_fields.html.erb
+++ b/app/views/posts/_post_video_fields.html.erb
@@ -8,5 +8,5 @@
 </div>
 <!-- 削除ボタン -->
 <div class="text-right">
-  <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
+  <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md"><%= t('helpers.submit.delete') %></button>
 </div>

--- a/app/views/posts/_post_video_fields.html.erb
+++ b/app/views/posts/_post_video_fields.html.erb
@@ -1,0 +1,12 @@
+<div class="mb-4">
+  <%= form.label :youtube_url, class: 'block text-sm font-medium text-gray-700' %>
+  <%= form.text_field :youtube_url, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+</div>
+<div class="mb-4">
+  <%= form.label :caption, class: 'block text-sm font-medium text-gray-700' %>
+  <%= form.text_field :caption, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+</div>
+<!-- 削除ボタン -->
+<div class="text-right">
+  <button data-action="nested-form#remove" class="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-3 rounded-md">削除</button>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,10 +4,10 @@
       <!-- 検索フォーム -->
       <%= form_with model: @search_posts_form, scope: :query, url: posts_path, method: :get do |f| %>
         <div>
-          <%= f.search_field :keyword, value: @search_posts_form.keyword, placeholder: 'キーワードで検索' %>
+          <%= f.search_field :keyword, value: @search_posts_form.keyword, placeholder: t('.place_holder') %>
         </div>
         <div>
-          <%= f.submit '検索' %>
+          <%= f.submit t('.search_submit') %>
         </div>
       <% end %>
     </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -16,8 +16,7 @@ ja:
         body: コメント
       post_image:
         image: サブ画像
-        caption: サブ画像の説明文
+        caption: 説明文
       post_video:
-        youtube_url: YouTube共有URL（YouTube動画の共有ボタンからコピーしたURLを入力してください）
-        caption: YouTube動画の説明文
-    # errors.models: バリデーションエラー
+        youtube_url: YouTube動画URL（共有ボタンからコピーしたURLを入力してください）
+        caption: 説明文

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -15,12 +15,16 @@ ja:
       no_posts: 掲示板がありません
       search_placeholder: 検索ワード
       search_submit: 検索
+      place_holder: キーワードで検索
     new:
       title: 新規投稿
     edit:
       title: 投稿編集
     show:
       title: さんのSUKI
+    form:
+      post_images: サブ画像
+      post_videos: Youtube動画
   profiles:
     show:
       title: さんのプロフィール
@@ -48,6 +52,7 @@ ja:
       update: 更新
       edit: 編集
       delete: 削除
+      addition: 追加
       xshare: Xシェア
     confirm:
       delete: 本当に削除しますか？


### PR DESCRIPTION
## issue番号
closes #109  
closes #110  
closes #111  

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 新規投稿フォーム内で、サブ画像とYouTube URLのフォームを動的に追加できるように実装（Stimulus使用）
  - ボタンを押すことで、上限なしにフォームを追加可能

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `index.js` の編集
- `nested_form_controller` の生成とロジック実装
- `_form.html.erb` の編集と共通部分のパーシャル化
- `posts_controller` の `post_params` に `_destroy` を追加（フォーム削除実装のため）
- `post_decorator` および `posts_controller` 内の `prepare_nested_forms` を削除
  - これまで `prepare_nested_forms` 内でフォームを `build` していたが、`_form.html.erb` 内で `fields_for ... Post.new` を使用することで、追加時にフォームを生成するように変更
- i18n 対応

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 新規投稿時にサブ画像やYouTube動画を上限なく追加可能

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカル環境で新規作成、編集、削除の挙動確認を実施

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
