### PR TITLE
add：既存の検索機能に、ユーザー名検索を追加

### DIFF
--- a/app/finders/posts_finder.rb
+++ b/app/finders/posts_finder.rb
@@ -19,7 +19,7 @@ class PostsFinder
     return if @q.keyword.blank?
 
     keyword = like_search_condition(@q.keyword)
-    @record = @record.where('title LIKE ? OR body LIKE ?', keyword, keyword)
+    @record = @record.joins(:user).where('posts.title LIKE ? OR posts.body LIKE ? OR users.name LIKE ?', keyword, keyword, keyword)
   end
 
   # like検索

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,9 +13,8 @@ ja:
     index:
       title: 投稿一覧
       no_posts: '掲示板がありません'
-      search_placeholder: 検索ワード
       search_submit: 検索
-      place_holder: キーワードで検索
+      place_holder: 検索ワードを入力（ユーザー名・タイトル・推しポイント）
     post:
       owner_suki: さんのスキ！
       no_image: 画像未設定


### PR DESCRIPTION
## issue番号
close #127 
## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 既存の検索機能に、ユーザー名検索機能を追加

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `posts_finder`の`search_keyword`メソッド修正
  - userテーブルをjoinして、users.name LIKE?で検索
- 検索フォームのプレースホルダーを編集
  - 編集後　👉 　検索ワードを入力（ユーザー名・タイトル・推しポイント）

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 投稿一覧の検索フォームで、ユーザー名を入力して、ユーザーの投稿を絞り込み可能になる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルでの挙動を確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし