### PR TITLE
fix：サブ画像が投稿できない

### DIFF
--- a/app/models/post_image.rb
+++ b/app/models/post_image.rb
@@ -1,7 +1,7 @@
 class PostImage < ApplicationRecord
   belongs_to :post
 
-  validates :image, presence: true, length: { maximum: 255 }
+  validates :image, presence: true
   validates :caption, length: { maximum: 65_535 }
 
   mount_uploader :image, PostImageUploader


### PR DESCRIPTION
## issue番号


## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- エラー状況：サブ画像がバリデーションに引っかかって保存できない不具合の修正

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 原因：
  - サブ画像（post_images）の `image` に設定していた `length: { maximum: 255 }` のバリデーションに引っかかっていたため、バリデーションを削除
  - 実際に保存されたデータをコンソールで確認したところ、`"614adc21-48d0-4a60-9dda-5f19ac1f27de.webp"` のように40文字程度で、DB上の制限には抵触していないことを確認
  - ただし、保存前に255文字を超えるファイル名が一時的に渡っている可能性もあり、根本原因は特定できていない
  - 現時点では納期優先のため、暫定対応としてバリデーションの削除で解消

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- サブ画像付きの投稿が正常に行えるようになる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカル環境にて、サブ画像を含んだ投稿が正常に保存・表示されることを確認

## その他
<!-- レビュワーへの参考情報 -->
- 恒久対応については、必要に応じて別Issue・PRにて対応予定

## 関連Issue
<!-- このPRが関連するIssue -->
- なし
