### PR TITLE
feature：投稿ブックマーク機能追加

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,14 @@
+class BookmarksController < ApplicationController
+
+	def create
+		@post = Post.find(params[:post_id])
+		current_user.bookmark(@post)
+		# create.turbo_streamをレンダリング
+	end
+
+	def destroy
+		@post = current_user.bookmarks.find(params[:id]).post
+		current_user.unbookmark(@post)
+		# destroy.turbo_streamをレンダリング
+	end
+end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,15 +1,14 @@
 class BookmarksController < ApplicationController
+  def create
+    @post = Post.find(params[:post_id])
+    current_user.bookmark(@post)
+    # create.turbo_streamをレンダリング
+    @current_user_bookmarks = current_user.present? ? current_user.bookmarks.index_by(&:post_id) : {}
+  end
 
-	def create
-		@post = Post.find(params[:post_id])
-		current_user.bookmark(@post)
-		# create.turbo_streamをレンダリング
-		@current_user_bookmarks = current_user.present? ? current_user.bookmarks.index_by(&:post_id) : {}
-	end
-
-	def destroy
-		@post = current_user.bookmarks.find(params[:id]).post
-		current_user.unbookmark(@post)
-		# destroy.turbo_streamをレンダリング
-	end
+  def destroy
+    @post = current_user.bookmarks.find(params[:id]).post
+    current_user.unbookmark(@post)
+    # destroy.turbo_streamをレンダリング
+  end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -4,6 +4,7 @@ class BookmarksController < ApplicationController
 		@post = Post.find(params[:post_id])
 		current_user.bookmark(@post)
 		# create.turbo_streamをレンダリング
+		@current_user_bookmarks = current_user.present? ? current_user.bookmarks.index_by(&:post_id) : {}
 	end
 
 	def destroy

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,6 +6,7 @@ class PostsController < ApplicationController
     @search_posts_form = SearchPostsForm.new(search_post_params) # 検索条件を保持
     @posts = PostsFinder.new(@search_posts_form).search.includes(:user, :post_videos, :categories).order(created_at: :desc) # 　検索を実行する
     @current_user_likes = current_user.present? ? current_user.likes.where(likeable_type: 'Post').index_by(&:likeable_id) : {}
+    @current_user_bookmarks = current_user.present? ? current_user.bookmarks.index_by(&:post_id) : {}
   end
 
   def show

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -17,9 +17,8 @@ module NotificationsHelper
     tag.svg(xmlns: 'http://www.w3.org/2000/svg',
             fill: fill,
             viewBox: '0 0 24 24',
-            'stroke-width': '1.5',
             stroke: 'currentColor',
-            class: 'size-6') do
+            class: 'size-7') do
       tag.path('stroke-linecap': 'round',
                'stroke-linejoin': 'round',
                d: 'M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 ' \

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,2 @@
+class Bookmark < ApplicationRecord
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,6 +1,6 @@
 class Bookmark < ApplicationRecord
-  belongs_to: user
-  belongs_to: post
+  belongs_to :user
+  belongs_to :post
 
   validates :user_id, uniqueness: { scope: :post_id }
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,2 +1,6 @@
 class Bookmark < ApplicationRecord
+  belongs_to: user
+  belongs_to: post
+
+  validates :user_id, uniqueness: { scope: :post_id }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,6 +10,7 @@ class Post < ApplicationRecord
   accepts_nested_attributes_for :post_videos, allow_destroy: true, reject_if: :all_blank
   has_many :post_categories, dependent: :destroy
   has_many :categories, through: :post_categories
+  has_many :bookmarks, dependent: :destroy
 
   mount_uploader :image, ImageUploader
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,11 +11,12 @@ class User < ApplicationRecord
   has_many :active_notifications, class_name: 'Notification', inverse_of: :visitor, foreign_key: 'visitor_id', dependent: :destroy
   has_many :passive_notifications, class_name: 'Notification', inverse_of: :visited, foreign_key: 'visited_id', dependent: :destroy
   has_many :bookmarks, dependent: :destroy
-  has_many :bookmark_posts, through: :bookmarks, source: :post
+
 
   # 　下記プロフィール画面で使用予定
   has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post', dependent: :destroy
   has_many :liked_comments, through: :likes, source: :likeable, source_type: 'Comment', dependent: :destroy
+  has_many :bookmark_posts, through: :bookmarks, source: :post
 
   validates :name, presence: true, length: { maximum: 30 }
 
@@ -41,7 +42,4 @@ class User < ApplicationRecord
     bookmark_posts.destroy(post)
   end
 
-  def bookmark?(post)
-    bookmarks.exists?(post_id: post.id)
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,17 @@ class User < ApplicationRecord
   def unlike(likeable)
     likes.find_by(likeable: likeable)&.destroy
   end
+
+  #bookmarkコントローラーで使用
+  def bookmark(post)
+    bookmarks.create(post: post)
+  end
+
+  def unbookmark(post)
+    bookmark_posts.destroy(post)
+  end
+
+  def bookmark?(post)
+    bookmarks.exists?(post_id: post.id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :active_notifications, class_name: 'Notification', inverse_of: :visitor, foreign_key: 'visitor_id', dependent: :destroy
   has_many :passive_notifications, class_name: 'Notification', inverse_of: :visited, foreign_key: 'visited_id', dependent: :destroy
+  has_many :bookmarks, dependent: :destroy
+  has_many :bookmark_posts, through: :bookmarks, source: :post
 
   # 　下記プロフィール画面で使用予定
   has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post', dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,6 @@ class User < ApplicationRecord
   has_many :passive_notifications, class_name: 'Notification', inverse_of: :visited, foreign_key: 'visited_id', dependent: :destroy
   has_many :bookmarks, dependent: :destroy
 
-
   # 　下記プロフィール画面で使用予定
   has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post', dependent: :destroy
   has_many :liked_comments, through: :likes, source: :likeable, source_type: 'Comment', dependent: :destroy
@@ -33,7 +32,7 @@ class User < ApplicationRecord
     likes.find_by(likeable: likeable)&.destroy
   end
 
-  #bookmarkコントローラーで使用
+  # bookmarkコントローラーで使用
   def bookmark(post)
     bookmarks.create(post: post)
   end
@@ -41,5 +40,4 @@ class User < ApplicationRecord
   def unbookmark(post)
     bookmark_posts.destroy(post)
   end
-
 end

--- a/app/views/bookmarks/_bookmark_button.html.erb
+++ b/app/views/bookmarks/_bookmark_button.html.erb
@@ -1,5 +1,5 @@
 <%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-#{post.id}", data: { turbo_method: :post } do %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"  stroke="currentColor" class="size-6">
-  <path stroke-linecap="round" stroke-linejoin="round"   d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="size-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
 </svg>
 <% end %>

--- a/app/views/bookmarks/_bookmark_button.html.erb
+++ b/app/views/bookmarks/_bookmark_button.html.erb
@@ -1,6 +1,5 @@
-<%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
+<%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-#{post.id}", data: { turbo_method: :post } do %>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"  stroke="currentColor" class="size-6">
+  <path stroke-linecap="round" stroke-linejoin="round"   d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
 </svg>
-
 <% end %>

--- a/app/views/bookmarks/_bookmark_button.html.erb
+++ b/app/views/bookmarks/_bookmark_button.html.erb
@@ -1,0 +1,6 @@
+<%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
+</svg>
+
+<% end %>

--- a/app/views/bookmarks/_bookmark_buttons.html.erb
+++ b/app/views/bookmarks/_bookmark_buttons.html.erb
@@ -1,0 +1,9 @@
+<% if user_signed_in? %>
+  <div class='ms-auto'>
+    <% if current_user.bookmark?(post) %>
+      <%= render 'bookmarks/unbookmark_button', { post: post } %>
+    <% else %>
+      <%= render 'bookmarks/bookmark_button', { post: post } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/bookmarks/_bookmark_buttons.html.erb
+++ b/app/views/bookmarks/_bookmark_buttons.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
   <div class='ms-auto'>
-    <% if current_user.bookmark?(post) %>
+    <% if @current_user_bookmarks[post.id].present? %>
       <%= render 'bookmarks/unbookmark_button', { post: post } %>
     <% else %>
       <%= render 'bookmarks/bookmark_button', { post: post } %>

--- a/app/views/bookmarks/_unbookmark_button.html.erb
+++ b/app/views/bookmarks/_unbookmark_button.html.erb
@@ -1,0 +1,5 @@
+<%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+  <path fill-rule="evenodd" d="M6.32 2.577a49.255 49.255 0 0 1 11.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 0 1-1.085.67L12 18.089l-7.165 3.583A.75.75 0 0 1 3.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93Z" clip-rule="evenodd" />
+</svg>
+<% end %>

--- a/app/views/bookmarks/_unbookmark_button.html.erb
+++ b/app/views/bookmarks/_unbookmark_button.html.erb
@@ -1,5 +1,5 @@
 <%= link_to bookmark_path(@current_user_bookmarks[post.id]), id: "unbookmark-button-#{post.id}", data: { turbo_method: :delete } do %>
-<svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-blue-500" viewBox="0 0 24 24" fill="currentColor" >
+<svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-blue-500" viewBox="0 0 24 24" fill="currentColor">
   <path fill-rule="evenodd" d="M6.32 2.577a49.255 49.255 0 0 1 11.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 0 1-1.085.67L12 18.089l-7.165 3.583A.75.75 0 0 1 3.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93Z" clip-rule="evenodd" />
 </svg>
 <% end %>

--- a/app/views/bookmarks/_unbookmark_button.html.erb
+++ b/app/views/bookmarks/_unbookmark_button.html.erb
@@ -1,5 +1,5 @@
-<%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
+<%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-#{post.id}", data: { turbo_method: :delete } do %>
+<svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-blue-500" viewBox="0 0 24 24" fill="currentColor" >
   <path fill-rule="evenodd" d="M6.32 2.577a49.255 49.255 0 0 1 11.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 0 1-1.085.67L12 18.089l-7.165 3.583A.75.75 0 0 1 3.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93Z" clip-rule="evenodd" />
 </svg>
 <% end %>

--- a/app/views/bookmarks/_unbookmark_button.html.erb
+++ b/app/views/bookmarks/_unbookmark_button.html.erb
@@ -1,4 +1,4 @@
-<%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-#{post.id}", data: { turbo_method: :delete } do %>
+<%= link_to bookmark_path(@current_user_bookmarks[post.id]), id: "unbookmark-button-#{post.id}", data: { turbo_method: :delete } do %>
 <svg xmlns="http://www.w3.org/2000/svg" class="size-6 text-blue-500" viewBox="0 0 24 24" fill="currentColor" >
   <path fill-rule="evenodd" d="M6.32 2.577a49.255 49.255 0 0 1 11.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 0 1-1.085.67L12 18.089l-7.165 3.583A.75.75 0 0 1 3.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93Z" clip-rule="evenodd" />
 </svg>

--- a/app/views/bookmarks/create.turbo_stream.erb
+++ b/app/views/bookmarks/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bookmark-button-for-post-#{@post.id}" do %>
+  <%= render 'bookmarks/unbookmark_button', post: @post %>
+<% end %>

--- a/app/views/bookmarks/create.turbo_stream.erb
+++ b/app/views/bookmarks/create.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace "bookmark-button-for-post-#{@post.id}" do %>
+<%= turbo_stream.replace "bookmark-button-#{@post.id}" do %>
   <%= render 'bookmarks/unbookmark_button', post: @post %>
 <% end %>

--- a/app/views/bookmarks/destroy.turbo_stream.erb
+++ b/app/views/bookmarks/destroy.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace "unbookmark-button-for-post-#{@post.id}" do %>
+<%= turbo_stream.replace "unbookmark-button-#{@post.id}" do %>
   <%= render 'bookmarks/bookmark_button', post: @post %>
 <% end %>

--- a/app/views/bookmarks/destroy.turbo_stream.erb
+++ b/app/views/bookmarks/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "unbookmark-button-for-post-#{@post.id}" do %>
+  <%= render 'bookmarks/bookmark_button', post: @post %>
+<% end %>

--- a/app/views/likes/_like_button.html.erb
+++ b/app/views/likes/_like_button.html.erb
@@ -1,5 +1,5 @@
 <%= link_to likes_path(likeable_type: likeable.class.name, likeable_id: likeable.id), id: "like-button-#{likeable.id}", data: { turbo_method: :post } do %>
   <svg xmlns="http://www.w3.org/2000/svg" class="size-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-    <path stroke-linecap="round" stroke-linejoin="round"  d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
   </svg>
 <% end %>

--- a/app/views/likes/_like_button.html.erb
+++ b/app/views/likes/_like_button.html.erb
@@ -1,6 +1,5 @@
-<%= link_to likes_path(likeable_type: likeable.class.name, likeable_id: likeable.id), id: "like-button-#{likeable.id}", data: { turbo_method: :post },
-                                                                                      class: 'btn btn-ghost' do %>
-  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+<%= link_to likes_path(likeable_type: likeable.class.name, likeable_id: likeable.id), id: "like-button-#{likeable.id}", data: { turbo_method: :post } do %>
+  <svg xmlns="http://www.w3.org/2000/svg" class="size-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round"  d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
   </svg>
 <% end %>

--- a/app/views/likes/_like_buttons.html.erb
+++ b/app/views/likes/_like_buttons.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
   <div class='ms-auto'>
-    <% if @current_user_likes && @current_user_likes[likeable.id].present? %>
+    <% if @current_user_likes[likeable.id].present? %>
       <%= render 'likes/unlike_button', { likeable: likeable } %>
     <% else %>
       <%= render 'likes/like_button', { likeable: likeable } %>

--- a/app/views/likes/_unlike_button.html.erb
+++ b/app/views/likes/_unlike_button.html.erb
@@ -1,8 +1,9 @@
 
 <% like = @current_user_likes[likeable.id] %>
 <!-- destoryなので、like_idも渡す -->
-<%= link_to like_path(id: like.id, likeable_type: likeable.class.name, likeable_id: likeable.id), id: "unlike-button-#{likeable.id}",data: { turbo_method: :delete } do %>
-  <svg xmlns="http://www.w3.org/2000/svg" class="size-7 text-red-500" fill="currentColor" viewBox="0 0 24 24" >
+<%= link_to like_path(id: like.id, likeable_type: likeable.class.name, likeable_id: likeable.id), id: "unlike-button-#{likeable.id}",
+                                                                                                  data: { turbo_method: :delete } do %>
+  <svg xmlns="http://www.w3.org/2000/svg" class="size-7 text-red-500" fill="currentColor" viewBox="0 0 24 24">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
   </svg>
 <% end %>

--- a/app/views/likes/_unlike_button.html.erb
+++ b/app/views/likes/_unlike_button.html.erb
@@ -1,9 +1,8 @@
 
 <% like = @current_user_likes[likeable.id] %>
 <!-- destoryなので、like_idも渡す -->
-<%= link_to like_path(id: like.id, likeable_type: likeable.class.name, likeable_id: likeable.id), id: "unlike-button-#{likeable.id}",
-                                                                                                  data: { turbo_method: :delete }, class: 'btn btn-ghost' do %>
-  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-red-500" fill="currentColor" viewBox="0 0 24 24" stroke="currentColor">
+<%= link_to like_path(id: like.id, likeable_type: likeable.class.name, likeable_id: likeable.id), id: "unlike-button-#{likeable.id}",data: { turbo_method: :delete } do %>
+  <svg xmlns="http://www.w3.org/2000/svg" class="size-7 text-red-500" fill="currentColor" viewBox="0 0 24 24" >
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
   </svg>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <h2 class="text-2xl font-bold mb-6"><%= t('.title') %></h2>
   <% if @notifications.present? %>
-    <%= link_to '全削除', notification_path(@notifications), data: { turbo_method: :delete }, class: 'btn btn-light' %>
+    <%= link_to '全削除', notification_path(@notifications), data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') }, class: 'btn btn-light' %>
     <div class="space-y-4">
       <%= render @notifications %>
     </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -38,6 +38,9 @@
       <div class="p-4">
         <%= render 'likes/like_buttons', { likeable: post } %>
       </div>
+      <div class="p-4">
+        <%= render 'bookmarks/bookmark_buttons', { post: post } %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -35,11 +35,15 @@
           </div>
         <% end %>
       </div>
-      <div class="p-4">
-        <%= render 'likes/like_buttons', { likeable: post } %>
-      </div>
-      <div class="p-4">
-        <%= render 'bookmarks/bookmark_buttons', { post: post } %>
+      <div class="p-2 flex justify-center items-center">
+        <div class="flex gap-6 items-center">
+          <div>
+            <%= render 'likes/like_buttons', { likeable: post } %>
+          </div>
+          <div>
+            <%= render 'bookmarks/bookmark_buttons', { post: post } %>
+          </div>
+        </div>
       </div>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,16 +5,14 @@ Rails.application.routes.draw do
 
   root 'staticpages#top'
 
-  # post,commentで共通のpathを使用するため、一番post,commentにそれぞれネストしない
-  # 共通のpathを使うのは、同じviewでpost,commentのlikeを表示するため
-  resources :likes, only: %i[create destroy]
-
   resources :posts do
     resources :comments, only: %i[create edit update destroy]
   end
 
+  resources :likes, only: %i[create destroy]
+  resources :bookmarks, only: %i[create destroy]
+  
   resource :profile, only: %i[show edit update]
-
   resources :notifications, only: %i[index destroy]
 
   get 'ogp/ogp.png', to: 'ogp_images#show', as: :ogp_image

--- a/db/migrate/20250321083838_create_bookmarks.rb
+++ b/db/migrate/20250321083838_create_bookmarks.rb
@@ -1,0 +1,11 @@
+class CreateBookmarks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :bookmarks, id: :uuid do |t|
+      t.references :post, null: false, foreign_key: true, type: :uuid
+      t.references :user, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+    add_index :bookmarks, [:post_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_16_125020) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_21_083838) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "bookmarks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "post_id", null: false
+    t.uuid "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id", "user_id"], name: "index_bookmarks_on_post_id_and_user_id", unique: true
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
 
   create_table "categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
@@ -113,6 +123,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_16_125020) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "notifications", "users", column: "visited_id"


### PR DESCRIPTION
## issue番号
closes #130 
closes #131 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿ブックマーク機能を追加（ログインユーザーのみ）

## やったこと
<!-- このプルリクで何をしたのか？ -->
- ブックマークテーブル作成（postとuserの中間テーブル）
- モデル関連付け
- ルーティング追加
- `posts`コントローラー編集
  - n+1回避のため` @current_user_bookmarks`でハッシュ形式で一括取得
- ブックマークコントローラー作成
  - `create,destory.turbo_stream.html.erb`を使用して、非同期でブックマーク可能に
- viewファイル生成・編集
- Lint修正
　
- 通知、いいね、ブックマークボタンのサイズ調整

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- ブックマークした投稿を見ること
  - 今後マイページで見ることができるようにする

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 投稿をブックマークすることが可能になる（ログインユーザーのみ）

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで挙動の確認
- コンソールでデータ保存の確認
[![Image from Gyazo](https://i.gyazo.com/575186c9731b8c49e491678e3cca7e92.png)](https://gyazo.com/575186c9731b8c49e491678e3cca7e92)

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし