### PR TITLE
feature：プロフィール画像

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name]) #ユーザー登録
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar]) #　ユーザー編集
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name]) #ユーザー登録
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :avatar]) #　ユーザー編集
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name]) # ユーザー登録
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[name avatar]) # 　ユーザー編集
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,8 +1,7 @@
 class Users::ConfirmationsController < Devise::ConfirmationsController
+  protected
 
-protected
-
-  def after_confirmation_path_for(resource_name, resource)
+  def after_confirmation_path_for(_resource_name, resource)
     sign_in(resource)
     root_path
   end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,9 @@
+class Users::ConfirmationsController < Devise::ConfirmationsController
+
+protected
+
+  def after_confirmation_path_for(resource_name, resource)
+    sign_in(resource)
+    root_path
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,13 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
+  # ユーザー編集後の遷移先
   def after_update_path_for(_resource)
     profile_path
+  end
+
+  # パスワード入力なしで編集
+  def update_resource(resource, params)
+    resource.update_without_password(params)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ApplicationRecord
   has_many :liked_comments, through: :likes, source: :likeable, source_type: 'Comment', dependent: :destroy
   has_many :bookmark_posts, through: :bookmarks, source: :post
 
+  mount_uploader :avatar, AvatarUploader
+
   validates :name, presence: true, length: { maximum: 30 }
 
   def own?(object)

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -16,7 +16,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w[jpg jpeg gif png heic webp]
+    %w[jpg jpeg gif png webp]
   end
 
   process resize_to_fit: [300, 300]

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -19,7 +19,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
     %w[jpg jpeg gif png webp]
   end
 
-  process resize_to_fit: [300, 300]
+  process resize_to_fit: [256, 256]
   process :convert_to_webp
   process :optimize
 

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,47 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
+
+  if Rails.env.production?
+    storage :fog # 本番環境ではS3に保存
+  else
+    storage :file # 開発・テスト環境ではローカルに保存
+  end
+
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  def size_range
+    (1.byte)..(10.megabytes)
+  end
+
+  def extension_allowlist
+    %w[jpg jpeg gif png heic webp]
+  end
+
+  process resize_to_fit: [300, 300]
+  process :convert_to_webp
+  process :optimize
+
+  private
+
+  def convert_to_webp
+    manipulate! do |img|
+      img.format('webp')
+      img
+    end
+  end
+
+  # 内部的に呼び出されるメソッド,filenameをオーバーライドしている
+  def filename
+    "#{super.chomp(File.extname(super))}.webp" if original_filename.present?
+  end
+
+  def optimize
+    manipulate! do |img|
+      img.strip # メタデータ削除
+      img.quality 80
+      img
+    end
+  end
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -16,7 +16,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w[jpg jpeg gif png ]
+    %w[jpg jpeg gif png]
   end
 
   process resize_to_fit: [1200, 630]
@@ -56,6 +56,4 @@ class ImageUploader < CarrierWave::Uploader::Base
   #   extension = File.extname(super).downcase == '.heic' ? 'jpg' : File.extname(super).downcase.delete('.')
   #   "#{base_name}.#{extension}"
   # end
-
-
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -16,40 +16,18 @@ class ImageUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w[jpg jpeg gif png heic]
+    %w[jpg jpeg gif png ]
   end
 
   process resize_to_fit: [1200, 630]
-  process :convert_heic_to_jpg, if: :heic?
   process :optimize
 
   version :mini do
     process resize_to_fill: [400, 300]
-    process :convert_heic_to_jpg, if: :heic?
     process :optimize
   end
 
   private
-
-  def heic?(file)
-    file.extension.downcase == 'heic'
-  end
-
-  def convert_heic_to_jpg
-    manipulate! do |img|
-      img.format('jpg')
-      img
-    end
-  end
-
-  # 内部的に呼び出されるメソッド,filenameをオーバーライドしている
-  def filename
-    return if super.blank? # CarrierWave のデフォルトの filename が存在するか確認
-
-    base_name = File.basename(super, '.*')
-    extension = File.extname(super).downcase == '.heic' ? 'jpg' : File.extname(super).downcase.delete('.')
-    "#{base_name}.#{extension}"
-  end
 
   def optimize
     manipulate! do |img|
@@ -58,4 +36,26 @@ class ImageUploader < CarrierWave::Uploader::Base
       img
     end
   end
+
+  # def heic?(file)
+  #   file.extension.downcase == 'heic'
+  # end
+
+  # def convert_heic_to_jpg
+  #   manipulate! do |img|
+  #     img.format('jpg')
+  #     img
+  #   end
+  # end
+
+  # 内部的に呼び出されるメソッド,filenameをオーバーライドしている
+  # def filename
+  #   return if super.blank? # CarrierWave のデフォルトの filename が存在するか確認
+
+  #   base_name = File.basename(super, '.*')
+  #   extension = File.extname(super).downcase == '.heic' ? 'jpg' : File.extname(super).downcase.delete('.')
+  #   "#{base_name}.#{extension}"
+  # end
+
+
 end

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -16,7 +16,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
   end
 
   def extension_allowlist
-    %w[jpg jpeg gif png heic webp]
+    %w[jpg jpeg gif png webp]
   end
 
   process resize_to_fit: [500, 500]

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,6 +4,11 @@
   <%= render 'devise/shared/error_messages', resource: resource %>
 
   <div class="field">
+    <%= f.label :avatar %><br>
+    <%= f.file_field :avatar,accept: 'image/jpg,image/jpeg,image/png,image/gif,image/heic,image/webp' %>
+  </div>
+
+  <div class="field">
     <%= f.label :name %><br>
     <%= f.text_field :name, autofocus: true, autocomplete: 'name' %>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :avatar %><br>
-    <%= f.file_field :avatar,accept: 'image/jpg,image/jpeg,image/png,image/gif,image/webp' %>
+    <%= f.file_field :avatar, accept: 'image/jpg,image/jpeg,image/png,image/gif,image/webp' %>
   </div>
 
   <div class="field">
@@ -43,4 +43,3 @@
 
 <%= button_to t('.cancel_my_account'), registration_path(resource_name),
               data: { confirm: t('.are_you_sure'), turbo_confirm: t('.are_you_sure') }, method: :delete %></div>
-

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :avatar %><br>
-    <%= f.file_field :avatar,accept: 'image/jpg,image/jpeg,image/png,image/gif,image/heic,image/webp' %>
+    <%= f.file_field :avatar,accept: 'image/jpg,image/jpeg,image/png,image/gif,image/webp' %>
   </div>
 
   <div class="field">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -36,11 +36,6 @@
     <%= f.password_field :password_confirmation, autocomplete: 'new-password' %>
   </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br>
-    <%= f.password_field :current_password, autocomplete: 'current-password' %>
-  </div>
-
   <div class="actions">
     <%= f.submit t('.update') %>
   </div>
@@ -49,4 +44,3 @@
 <%= button_to t('.cancel_my_account'), registration_path(resource_name),
               data: { confirm: t('.are_you_sure'), turbo_confirm: t('.are_you_sure') }, method: :delete %></div>
 
-<%= link_to t('devise.shared.links.back'), :back %>

--- a/app/views/notifications/_commented.html.erb
+++ b/app/views/notifications/_commented.html.erb
@@ -1,4 +1,7 @@
 <div class="flex items-center">
+  <% if  notification.visitor.avatar.present? %>
+    <%= image_tag  notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
+  <% end %>
   <span class="font-semibold"><%= notification.visitor.name %></span>
   <span class="ml-2">
     があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にコメントしました

--- a/app/views/notifications/_commented.html.erb
+++ b/app/views/notifications/_commented.html.erb
@@ -1,6 +1,6 @@
 <div class="flex items-center">
   <% if  notification.visitor.avatar.present? %>
-    <%= image_tag  notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
+    <%= image_tag notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
   <% end %>
   <span class="font-semibold"><%= notification.visitor.name %></span>
   <span class="ml-2">

--- a/app/views/notifications/_liked.html.erb
+++ b/app/views/notifications/_liked.html.erb
@@ -1,4 +1,7 @@
 <div class="flex items-center">
+  <% if  notification.visitor.avatar.present? %>
+    <%= image_tag  notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
+  <% end %>
   <span class="font-semibold"><%= notification.visitor.name %></span>
   <span class="ml-2">
     <% if notification.notifiable_type == 'Post' %>

--- a/app/views/notifications/_liked.html.erb
+++ b/app/views/notifications/_liked.html.erb
@@ -1,6 +1,6 @@
 <div class="flex items-center">
   <% if  notification.visitor.avatar.present? %>
-    <%= image_tag  notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
+    <%= image_tag notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
   <% end %>
   <span class="font-semibold"><%= notification.visitor.name %></span>
   <span class="ml-2">

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white p-4 rounded-lg shadow <%= notification.checked? ? 'opacity-75' : '' %>">
+<div class="bg-white p-4 rounded-lg shadow">
   <!-- いいねかコメントでレンダリング先をわける -->
   <%= render "notifications/#{notification.action}", notification: notification %>
 </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -19,7 +19,7 @@
   </div>
   <div>
     <%= f.label :image, class: 'block text-sm font-medium text-gray-700' %>
-    <%= f.file_field :image, accept: 'image/jpg,image/jpeg,image/png,image/gif,image/heic',
+    <%= f.file_field :image, accept: 'image/jpg,image/jpeg,image/png,image/gif',
                              class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
   </div>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,12 @@
   <%= link_to post_path(post), class: 'block' do %>
     <div class="border rounded-lg bg-white hover:shadow-md transition-shadow duration-100">
       <div class="p-4">
-        <span class="font-semibold"><%= post.user.name %><%= t('.owner_suki') %></span>
+        <div class="flex items-center">
+          <% if post.user.avatar.present? %>
+            <%= image_tag post.user.avatar.url, class: 'w-12 h-12 object-cover rounded-full mr-3' %>
+          <% end %>
+          <span class="font-semibold"><%= post.user.name %></span>
+        </div>
       </div>
       <div class="px-4">
         <h4 class="text-lg font-bold text-center">

--- a/app/views/posts/_post_image_fields.html.erb
+++ b/app/views/posts/_post_image_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-4">
   <%= form.label :image, class: 'block text-sm font-medium text-gray-700' %>
-  <%= form.file_field :image, accept: 'image/jpg,image/jpeg,image/png,image/gif,image/heic,image/webp',
+  <%= form.file_field :image, accept: 'image/jpg,image/jpeg,image/png,image/gif,image/webp',
                               class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
 </div>
 <div class="mb-4">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,10 @@
 <div class="container mx-auto max-w-4xl px-4 py-8">
-  <h2 class="text-center"><%= @post.user.name %> <%= t('.title') %></h2>
+  <div class="flex items-center">
+    <% if @post.user.avatar.present? %>
+      <%= image_tag @post.user.avatar.url, class: 'w-16 h-16 object-cover rounded-full mr-3' %>
+    <% end %>
+    <span class="font-semibold"><%= @post.user.name %><%= t('.title') %></span>
+  </div>
 
   <h1 class="text-center text-2xl font-bold my-4">「<%= @post.title %>」</h1>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,7 +1,8 @@
 <div class="max-w-2xl mx-auto mt-8 p-6 bg-white rounded-lg shadow-md">
-  <h1 class="text-2xl font-bold mb-6">
-
-  <%= image_tag @user.avatar.url %><%= @user.name %> <%= t('.title') %></h1>
+   <% if @user.avatar.present? %>
+    <h1 class="text-2xl font-bold mb-6">
+    <%= image_tag @user.avatar.url %><%= @user.name %> <%= t('.title') %></h1>
+  <% end %>
 
   <div class="space-y-4">
     <div class="border-b pb-4">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,8 +1,8 @@
 <div class="max-w-2xl mx-auto mt-8 p-6 bg-white rounded-lg shadow-md">
-   <% if @user.avatar.present? %>
-    <h1 class="text-2xl font-bold mb-6">
-    <%= image_tag @user.avatar.url %><%= @user.name %> <%= t('.title') %></h1>
+  <% if @user.avatar.present? %>
+    <%= image_tag @user.avatar.url, class: 'w-32 h-32 object-cover rounded-full' %>
   <% end %>
+  <h1 class="text-2xl font-bold mb-6"><%= @user.name %> <%= t('.title') %></h1>
 
   <div class="space-y-4">
     <div class="border-b pb-4">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,7 @@
 <div class="max-w-2xl mx-auto mt-8 p-6 bg-white rounded-lg shadow-md">
-  <h1 class="text-2xl font-bold mb-6"><%= @user.name %> <%= t('.title') %></h1>
+  <h1 class="text-2xl font-bold mb-6">
+
+  <%= image_tag @user.avatar.url %><%= @user.name %> <%= t('.title') %></h1>
 
   <div class="space-y-4">
     <div class="border-b pb-4">

--- a/config/locales/devise/activerecord/ja.yml
+++ b/config/locales/devise/activerecord/ja.yml
@@ -11,6 +11,7 @@ ja:
         current_sign_in_ip: 現在のログインIPアドレス
         name: 名前
         email: Eメール
+        avatar: プロフィール画像
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -16,7 +16,6 @@ ja:
       search_submit: 検索
       place_holder: 検索ワードを入力（ユーザー名・タイトル・推しポイント）
     post:
-      owner_suki: さんのスキ！
       no_image: 画像未設定
     new:
       title: 新規投稿

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    confirmations: 'users/confirmations'
   }
 
   root 'staticpages#top'

--- a/db/migrate/20250324115902_add_avatar_to_users.rb
+++ b/db/migrate/20250324115902_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_21_083838) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_24_115902) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -118,6 +118,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_21_083838) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "avatar"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## issue番号
close #133 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- プロフィール画像を設定
- 修正
　heic形式の画像がアップロードできない
- その他コード修正

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `users`テーブルに`avatar`カラム追加(string)
- `Avatar`アップローダー生成して、カラムにマウント
  - 画像は[256,256]にリサイズしてアップロード
  - viewで使用する画像のサイズは最大で128px,128px、そのためRetinaディスプレイを考慮して2倍のサイズにリサイズ
- viewではavatar画像を丸く、サイズ調整して表示
  + tailwindのクラスをあてる（`w-32 h-32 object-cover rounded-full`）
  + 投稿一覧、詳細、通知一覧、プロフィール詳細
　
+ heic形式の画像がアップロードできないため修正
  + 各アップローダーでheic形式をアップロードできないようにする
  + viewでも`accept`オプション修正してアップロードできないようにする
　
+ ユーザー登録時、メール認証後に自動ログインしてトップページに遷移するように変更
　
+ ユーザー情報をパスワード入力なしで更新可能に変更

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- プロフィール画像未設定の場合の対応
  + 別issueで実施

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- プロフィール画像の設定
　
+ ユーザー登録時、メール認証後に自動ログイン、トップページに遷移
  + 今まではログインページに遷移され、ログイン情報を入力していた
　　
+ ユーザー情報更新をパスワード入力なしで可能にする
## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- heic形式の画像のアップロード

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで挙動の確認
+ 投稿一覧
[![Image from Gyazo](https://i.gyazo.com/ee963e2199ce8333fae2609333a1a886.png)](https://gyazo.com/ee963e2199ce8333fae2609333a1a886)
+ 投稿詳細
[![Image from Gyazo](https://i.gyazo.com/3d6a6718c6ce2ce2ce5094d130c92400.png)](https://gyazo.com/3d6a6718c6ce2ce2ce5094d130c92400)
+ プロフィール画面
[![Image from Gyazo](https://i.gyazo.com/8dfdeb013057e912a6b198f3e43fab96.png)](https://gyazo.com/8dfdeb013057e912a6b198f3e43fab96)
+ 通知画面
[![Image from Gyazo](https://i.gyazo.com/52a7ac418bab3d1c129370f0ea2edb74.png)](https://gyazo.com/52a7ac418bab3d1c129370f0ea2edb74)
+ メール認証後、自動ログイン、トップページに遷移
[![Image from Gyazo](https://i.gyazo.com/fa725d2c7233fc2806a5576ad447ffcf.png)](https://gyazo.com/fa725d2c7233fc2806a5576ad447ffcf)

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし