### PR TITLE
feature：ページネーション

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem 'meta-tags', require: 'meta_tags'
 
 gem 'draper'
 
+gem 'pagy', '~> 9.3'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
     nokogiri (1.18.1-x86_64-linux-musl)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pagy (9.3.4)
     parallel (1.26.3)
     parser (3.3.7.0)
       ast (~> 2.4.1)
@@ -441,6 +442,7 @@ DEPENDENCIES
   letter_opener_web
   meta-tags
   mini_magick
+  pagy (~> 9.3)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,31 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .pagy {
+	@apply flex justify-center items-center w-full mt-8 mb-8 text-xl space-x-1;
+  }
+  /* リンクボタン */
+  .pagy a:not(.gap) {
+    @apply block rounded-lg px-4 py-2 text-base bg-gray-200;
+  }
+  /* ホバー */
+  .pagy a:not(.gap):hover {
+    @apply bg-gray-300;
+  }
+  /* 前へ */
+  .pagy a:not(.gap):not([href]) {
+    @apply text-gray-300 bg-gray-100 cursor-default;
+  }
+  /* 現在のページ */
+  .pagy a:not(.gap).current {
+    @apply text-white bg-blue-500;
+  }
+  /* .pagy label {
+    @apply inline-block whitespace-nowrap bg-gray-200 rounded-lg px-4 py-2;
+  }
+  .pagy label input {
+    @apply bg-gray-100 border-none rounded-md;
+  } */
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pagy::Backend
+
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,6 +5,7 @@ class NotificationsController < ApplicationController
                                  .includes(:visitor, { notifiable: %i[post comment] })
                                  .order(created_at: :desc)
     @notifications.where(checked: false).update_all(checked: true)
+    @pagy, @notifications = pagy(@notifications, limit: 12)
   end
 
   def destroy

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,7 @@ class PostsController < ApplicationController
   def index
     @search_posts_form = SearchPostsForm.new(search_post_params) # 検索条件を保持
     @posts = PostsFinder.new(@search_posts_form).search.includes(:user, :post_videos, :categories).order(created_at: :desc) # 　検索を実行する
+    @pagy, @posts = pagy(@posts)
     @current_user_likes = current_user.present? ? current_user.likes.where(likeable_type: 'Post').index_by(&:likeable_id) : {}
     @current_user_bookmarks = current_user.present? ? current_user.bookmarks.index_by(&:post_id) : {}
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def flash_class(key)
     case key.to_sym # key が文字列でも対応できるように to_sym で変換
     when :notice then 'bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded-md shadow-md mb-4'

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -8,4 +8,6 @@
   <% else %>
     <p class="text-gray-500"><%= t('.no_notifications') %></p>
   <% end %>
+
+  <%== pagy_nav(@pagy) %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -37,4 +37,6 @@
       <div class="text-center"><%= t('.no_posts') %></div>
     <% end %>
   </div>
+
+  <%== pagy_nav(@pagy) %>
 </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (9.3.3)
+# Customize only what you really need and notice that the core Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/docs/api/pagy#variables
+# You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
+# Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
+# Here are the few that make more sense as DEFAULTs:
+# Pagy::DEFAULT[:limit]       = 20                    # default
+# Pagy::DEFAULT[:size]        = 7                     # default
+# Pagy::DEFAULT[:ends]        = true                  # default
+# Pagy::DEFAULT[:page_param]  = :page                 # default
+# Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
+# Pagy::DEFAULT[:max_pages]   = 3000                  # example
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/categories/extra
+
+
+# Legacy Compatibility Extras
+
+# Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
+# See https://ddnexus.github.io/pagy/docs/extras/size
+# require 'pagy/extras/size'   # must be required before the other extras
+
+
+# Backend Extras
+
+# Arel extra: For better performance utilizing grouped ActiveRecord collections:
+# See: https://ddnexus.github.io/pagy/docs/extras/arel
+# require 'pagy/extras/arel'
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/docs/extras/array
+# require 'pagy/extras/array'
+
+# Calendar extra: Add pagination filtering by calendar time unit (year, quarter, month, week, day)
+# See https://ddnexus.github.io/pagy/docs/extras/calendar
+# require 'pagy/extras/calendar'
+# Default for each calendar unit class in IRB:
+# >> Pagy::Calendar::Year::DEFAULT
+# >> Pagy::Calendar::Quarter::DEFAULT
+# >> Pagy::Calendar::Month::DEFAULT
+# >> Pagy::Calendar::Week::DEFAULT
+# >> Pagy::Calendar::Day::DEFAULT
+#
+# Uncomment the following lines, if you need calendar localization without using the I18n extra
+# module LocalizePagyCalendar
+#   def localize(time, opts)
+#     ::I18n.l(time, **opts)
+#   end
+# end
+# Pagy::Calendar.prepend LocalizePagyCalendar
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/docs/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::DEFAULT[:countless_minimal] = false   # default (eager loading)
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
+# Default :pagy_search method: change only if you use also
+# the searchkick or meilisearch extra that defines the same
+# Pagy::DEFAULT[:elasticsearch_rails_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:elasticsearch_rails_search] = :search
+# require 'pagy/extras/elasticsearch_rails'
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See https://ddnexus.github.io/pagy/docs/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::DEFAULT[:headers] = { page: 'Current-Page',
+#                            limit: 'Page-Items',
+#                            count: 'Total-Count',
+#                            pages: 'Total-Pages' }     # default
+
+# Keyset extra: Paginate with the Pagy keyset pagination technique
+# See https://ddnexus.github.io/pagy/docs/extras/keyset
+# require 'pagy/extras/keyset'
+
+# Meilisearch extra: Paginate `Meilisearch` result objects
+# See https://ddnexus.github.io/pagy/docs/extras/meilisearch
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or searchkick extra that define the same method
+# Pagy::DEFAULT[:meilisearch_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:meilisearch_search] = :ms_search
+# require 'pagy/extras/meilisearch'
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/docs/extras/metadata
+# you must require the JS Tools internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/js_tools'
+# require 'pagy/extras/metadata'
+# For performance reasons, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::DEFAULT[:metadata] = %i[scaffold_url page prev next last]   # example
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/docs/extras/searchkick
+# Default :pagy_search method: change only if you use also
+# the elasticsearch_rails or meilisearch extra that defines the same
+# Pagy::DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Default original :search method called internally to do the actual search
+# Pagy::DEFAULT[:searchkick_search] = :search
+# require 'pagy/extras/searchkick'
+# uncomment if you are going to use Searchkick.pagy_search
+# Searchkick.extend Pagy::Searchkick
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/docs/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Pagy extra: Add the pagy styled versions of the javascript-powered navs
+# and a few other components to the Pagy::Frontend module.
+# See https://ddnexus.github.io/pagy/docs/extras/pagy
+# require 'pagy/extras/pagy'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
+# Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
+
+
+# Feature Extras
+
+# Gearbox extra: Automatically change the limit per page depending on the page number
+# See https://ddnexus.github.io/pagy/docs/extras/gearbox
+# require 'pagy/extras/gearbox'
+# set to false only if you want to make :gearbox_extra an opt-in variable
+# Pagy::DEFAULT[:gearbox_extra] = false               # default true
+# Pagy::DEFAULT[:gearbox_limit] = [15, 30, 60, 100]   # default
+
+# Limit extra: Allow the client to request a custom limit per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/docs/extras/limit
+# require 'pagy/extras/limit'
+# set to false only if you want to make :limit_extra an opt-in variable
+# Pagy::DEFAULT[:limit_extra] = false    # default true
+# Pagy::DEFAULT[:limit_param] = :limit   # default
+# Pagy::DEFAULT[:limit_max]   = 100      # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/docs/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/docs/extras/trim
+# require 'pagy/extras/trim'
+# set to false only if you want to make :trim_extra an opt-in variable
+# Pagy::DEFAULT[:trim_extra] = false # default true
+
+# Standalone extra: Use pagy in non Rack environment/gem
+# See https://ddnexus.github.io/pagy/docs/extras/standalone
+# require 'pagy/extras/standalone'
+# Pagy::DEFAULT[:url] = 'http://www.example.com/subdir'  # optional default
+
+# Jsonapi extra: Implements JSON:API specifications
+# See https://ddnexus.github.io/pagy/docs/extras/jsonapi
+# require 'pagy/extras/jsonapi'   # must be required after the other extras
+# set to false only if you want to make :jsonapi an opt-in variable
+# Pagy::DEFAULT[:jsonapi] = false  # default true
+
+# Rails
+# Enable the .js file required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_limit_selector_js)
+# See https://ddnexus.github.io/pagy/docs/api/javascript
+
+# With the asset pipeline
+# Sprockets need to look into the pagy javascripts dir, so add it to the assets paths
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/docs/api/i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'de' },
+#                 { locale: 'en' },
+#                 { locale: 'es' })
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({ locale: 'en' },
+#                 { locale: 'es', filepath: 'path/to/pagy-es.yml' },
+#                 { locale: 'xyz',  # not built-in
+#                   filepath: 'path/to/pagy-xyz.yml',
+#                   pluralize: lambda{ |count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/docs/extras/i18n
+# require 'pagy/extras/i18n'
+
+
+# When you are done setting your own default freeze it, so it will not get changed accidentally
+Pagy::DEFAULT.freeze

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -10,9 +10,10 @@
 # You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
 # Here are the few that make more sense as DEFAULTs:
-# Pagy::DEFAULT[:limit]       = 20                    # default
-# Pagy::DEFAULT[:size]        = 7                     # default
-# Pagy::DEFAULT[:ends]        = true                  # default
+
+Pagy::DEFAULT[:limit]       = 6                    # 1ページに表示する投稿の最大数
+Pagy::DEFAULT[:size]        = 7                     # リンクの最大数
+Pagy::DEFAULT[:ends]        = true                  #　最後のページのリンクを表示する
 # Pagy::DEFAULT[:page_param]  = :page                 # default
 # Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
 # Pagy::DEFAULT[:max_pages]   = 3000                  # example

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -4,31 +4,27 @@
 # Customize only what you really need and notice that the core Pagy works also without any of the following lines.
 # Should you just cherry pick part of this file, please maintain the require-order of the extras
 
-
 # Pagy Variables
 # See https://ddnexus.github.io/pagy/docs/api/pagy#variables
 # You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
 # Here are the few that make more sense as DEFAULTs:
 
-Pagy::DEFAULT[:limit]       = 6                    # 1ページに表示する投稿の最大数
+Pagy::DEFAULT[:limit]       = 6 # 1ページに表示する投稿の最大数
 Pagy::DEFAULT[:size]        = 7                     # リンクの最大数
-Pagy::DEFAULT[:ends]        = true                  #　最後のページのリンクを表示する
+Pagy::DEFAULT[:ends]        = true                  # 　最後のページのリンクを表示する
 # Pagy::DEFAULT[:page_param]  = :page                 # default
 # Pagy::DEFAULT[:count_args]  = []                    # example for non AR ORMs
 # Pagy::DEFAULT[:max_pages]   = 3000                  # example
 
-
 # Extras
 # See https://ddnexus.github.io/pagy/categories/extra
-
 
 # Legacy Compatibility Extras
 
 # Size extra: Enable the Array type for the `:size` variable (e.g. `size: [1,4,4,1]`)
 # See https://ddnexus.github.io/pagy/docs/extras/size
 # require 'pagy/extras/size'   # must be required before the other extras
-
 
 # Backend Extras
 
@@ -112,7 +108,6 @@ Pagy::DEFAULT[:ends]        = true                  #　最後のページのリ
 # uncomment if you are going to use Searchkick.pagy_search
 # Searchkick.extend Pagy::Searchkick
 
-
 # Frontend Extras
 
 # Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
@@ -131,7 +126,6 @@ Pagy::DEFAULT[:ends]        = true                  #　最後のページのリ
 # Multi size var used by the *_nav_js helpers
 # See https://ddnexus.github.io/pagy/docs/extras/pagy#steps
 # Pagy::DEFAULT[:steps] = { 0 => 5, 540 => 7, 720 => 9 }   # example
-
 
 # Feature Extras
 
@@ -210,12 +204,10 @@ Pagy::DEFAULT[:ends]        = true                  #　最後のページのリ
 #                   filepath: 'path/to/pagy-xyz.yml',
 #                   pluralize: lambda{ |count| ... } )
 
-
 # I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
 # than the default pagy internal i18n (see above)
 # See https://ddnexus.github.io/pagy/docs/extras/i18n
 # require 'pagy/extras/i18n'
-
 
 # When you are done setting your own default freeze it, so it will not get changed accidentally
 Pagy::DEFAULT.freeze


### PR DESCRIPTION
## issue番号
closes #141 
closes #148 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿一覧、通知一覧にページネーションを追加
  - 読み込み速度を目的

## やったこと
<!-- このプルリクで何をしたのか？ -->
- gem `Pagy`インストール、実装
  - gem `kaminari`を採用しなかった理由
  - https://techracho.bpsinc.jp/hachi8833/2021_07_13/57481
  - 投稿一覧では1ページ6投稿表示、通知一覧では1ページに12通知表示
- 見た目は、公式のtailwindのコンポーネントを利用（app/assets/stylesheets/application.tailwind.css）
  - https://ddnexus.github.io/pagy/docs/api/stylesheets/#pagy-tailwind-css
- Lint修正

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 投稿一覧と、通知一覧の読み込みの速度向上

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- 投稿一覧
[![Image from Gyazo](https://i.gyazo.com/466820efb8191548e9e3c7cd02ca4513.jpg)](https://gyazo.com/466820efb8191548e9e3c7cd02ca4513)
- 通知一覧
[![Image from Gyazo](https://i.gyazo.com/4cc26a57d0b55499cf7ae8d5bf5bbd8b.png)](https://gyazo.com/4cc26a57d0b55499cf7ae8d5bf5bbd8b)

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし