### PR TITLE
refactor:ユーザープロフィール編集画面からパスワード変更欄を削除

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -22,20 +22,6 @@
     <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br>
-    <%= f.password_field :password, autocomplete: 'new-password' %>
-    <% if @minimum_password_length %>
-      <br>
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br>
-    <%= f.password_field :password_confirmation, autocomplete: 'new-password' %>
-  </div>
-
   <div class="actions">
     <%= f.submit t('.update') %>
   </div>


### PR DESCRIPTION
## issue番号
close #174 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- ユーザープロフィール編集画面からパスワード変更欄を削除　👉　変更されないエラーが発生していた
- パスワード変更はログイン画面「パスワードを忘れた場合はこちら」からパスワードリセットの手順で変更可能

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `app/views/devise/registrations/edit.html.erb`
　- パスワード入力欄を削除

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルでviewを確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし