### PR TITLE
style：通知画面レスポンシブ改善

### DIFF
--- a/app/views/notifications/_commented.html.erb
+++ b/app/views/notifications/_commented.html.erb
@@ -7,7 +7,8 @@
       <%= notification.visitor.name %>
     </span>
     <span class="ml-2 text-sm sm:text-base">
-      があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にコメントしました
+      があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post),
+                          class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にコメントしました
     </span>
   </div>
   <span class="text-gray-500 text-sm ml-2">

--- a/app/views/notifications/_commented.html.erb
+++ b/app/views/notifications/_commented.html.erb
@@ -1,11 +1,15 @@
-<div class="flex items-center">
-  <% if  notification.visitor.avatar.present? %>
-    <%= image_tag notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
-  <% end %>
-  <span class="font-semibold"><%= notification.visitor.name %></span>
-  <span class="ml-2">
-    があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にコメントしました
-  </span>
+<div class="flex items-center justify-between">
+  <div class="flex items-center ">
+    <% if notification.visitor.avatar.present? %>
+      <%= image_tag notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-2' %>
+    <% end %>
+    <span class="font-semibold text-sm sm:text-base">
+      <%= notification.visitor.name %>
+    </span>
+    <span class="ml-2 text-sm sm:text-base">
+      があなたの投稿「<%= link_to notification.notifiable.post.title, post_path(notification.notifiable.post), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にコメントしました
+    </span>
+  </div>
   <span class="text-gray-500 text-sm ml-2">
     <%= l notification.created_at, format: :long %>
   </span>

--- a/app/views/notifications/_liked.html.erb
+++ b/app/views/notifications/_liked.html.erb
@@ -1,15 +1,19 @@
-<div class="flex items-center">
-  <% if  notification.visitor.avatar.present? %>
-    <%= image_tag notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
-  <% end %>
-  <span class="font-semibold"><%= notification.visitor.name %></span>
-  <span class="ml-2">
-    <% if notification.notifiable_type == 'Post' %>
-      があなたの投稿「<%= link_to notification.notifiable.title, post_path(notification.notifiable), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にいいねしました
-    <% elsif notification.notifiable_type == 'Comment' %>
-      があなたのコメント「<%= link_to notification.notifiable.body, post_path(notification.notifiable.post), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にいいねしました
+<div class="flex items-center justify-between">
+  <div class="flex items-center ">
+    <% if  notification.visitor.avatar.present? %>
+      <%= image_tag notification.visitor.avatar.url, class: 'w-8 h-8 object-cover rounded-full mr-3' %>
     <% end %>
-  </span>
+    <span class="font-semibold text-sm sm:text-base">
+      <%= notification.visitor.name %>
+    </span>
+    <span class="ml-2 text-sm sm:text-base">
+      <% if notification.notifiable_type == 'Post' %>
+        があなたの投稿「<%= link_to notification.notifiable.title, post_path(notification.notifiable), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にいいねしました
+      <% elsif notification.notifiable_type == 'Comment' %>
+        があなたのコメント「<%= link_to notification.notifiable.body, post_path(notification.notifiable.post), class: 'text-blue-600 hover:text-blue-800 hover:underline' %>」にいいねしました
+      <% end %>
+    </span>
+  </div>
   <span class="text-gray-500 text-sm ml-2">
     <%= l notification.created_at, format: :long %>
   </span>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,6 +1,8 @@
 <div class="max-w-6xl mx-auto my-16">
   <div class="border rounded-lg bg-gray-50 p-4 sm:p-10 ">
-    <h2 class="text-2xl font-bold text-center mb-6"><%= t('.title') %></h2>
+    <h2 class="text-2xl text-center font-bold mb-6 ">
+      <%= t('.title') %>
+    </h2>
     <% if @notifications.present? %>
       <%= link_to '全削除', notification_path(@notifications), data: { turbo_method: :delete, turbo_confirm: t('helpers.confirm.delete') },
                                                             class: 'btn btn-light mb-4' %>


### PR DESCRIPTION
## issue番号
#164 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 通知一覧のレスポンシブ改善実施

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 実施したレスポンシブ内容
  - スマホサイズより大きくなった時に、文字サイズを大きくする　👉 `text-sm sm:text-base`

- viewの改善
  - アイコンと名前を左側、投稿時間を右にわけて配置　👉  `justify-between`
  - 余白のサイズの調整

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- スマホサイズの通知画面のviewの改善

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- 検証ツールで挙動を確認
- Rspecクリア

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし