### PR TITLE
refactor：投稿一覧の画像表示リファクター

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -45,11 +45,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   process resize_to_fit: [1200, 630]
   process :optimize
 
-  version :mini do
-    process resize_to_fill: [400, 300]
-    process :optimize
-  end
-
   private
 
   def optimize

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -14,7 +14,7 @@
         </h4>
       <div class="my-3">
         <% if post.image.present? %>
-          <%= image_tag post.image.mini.url, class: 'object-cover rounded-lg' %>
+          <%= image_tag post.image.url, class: 'w-[400px] h-[300px] object-cover rounded-lg' %>
         <% elsif post.post_videos.present? %>
           <div class="w-full aspect-video">
             <%= image_tag "https://img.youtube.com/vi/#{post.post_videos.first.youtube_url.to_s[0..10]}/hqdefault.jpg",


### PR DESCRIPTION
## issue番号


## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿一覧の画像表示の方法をリファクター

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 投稿一覧の画像をviewでリサイズして表示　`w-[400px] h-[300px]`
- 理由
  - cloudfront導入に伴い、urlをオーバーライドしているため、image.mini.urlが正しく動作しない
  - 投稿作成時の画像アップロード時に、時間がかなりかかってしまっていたため、  version :miniを適用しない（app/uploaders/image_uploader.rb）

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 投稿新規作成時のロード時間短縮

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- 投稿一覧の読み込みが遅くなる可能性

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで挙動の確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- #202 