### PR TITLE
Add：ローディングアニメーション

### DIFF
--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -1,53 +1,52 @@
 module PagyHelper
-	def custom_pagy_nav(pagy, id: nil, aria_label: nil, **vars)
-		id = %( id="#{id}") if id
-		a = pagy_anchor(pagy, **vars)
-  
-		html = %(<nav#{id} class="pagy nav" #{nav_aria_label(pagy, aria_label:)}>#{prev_a(pagy, a)})
-		pagy.series(**vars).each do |item| # series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
-		  html << case item
-				  when Integer
-					%(<a href="#{a.(item).match(/href="([^"]*)/)[1]}" data-action="click->loading#show">#{item}</a>)
-				  when String
-					%(<a role="link" aria-disabled="true" aria-current="page" class="current">#{pagy.label_for(item)}</a>)
-				  when :gap
-					%(<a role="link" aria-disabled="true" class="gap">#{pagy_t('pagy.gap')}</a>)
-				  else
-					raise InternalError, "expected item types in series to be Integer, String or :gap; got #{item.inspect}"
-				  end
-		end
-		html << %(#{next_a(pagy, a)}</nav>)
-	end
-  
-	# Similar to I18n.t: just ~18x faster using ~10x less memory
-	# (@pagy_locale explicitly initialized in order to avoid warning)
-	def pagy_t(key, **opts)
-		Pagy::I18n.translate(@pagy_locale ||= nil, key, **opts)
-	end
-  
-	private
-  
-	def nav_aria_label(pagy, aria_label: nil)
-		aria_label ||= pagy_t('pagy.aria_label.nav', count: pagy.pages)
-		%(aria-label="#{aria_label}")
-	end
-  
-	def prev_a(pagy, a, text: pagy_t('pagy.prev'), aria_label: pagy_t('pagy.aria_label.prev'))
-		if (p_prev = pagy.prev)
-		  href = a.(p_prev, text, aria_label:).match(/href="([^"]*)/)[1]
-		  %(<a href="#{href}" data-action="click->loading#show" aria-label="#{aria_label}">#{text}</a>)
-		else
-		  %(<a role="link" aria-disabled="true" aria-label="#{aria_label}">#{text}</a>)
-		end
-	end
-  
-	def next_a(pagy, a, text: pagy_t('pagy.next'), aria_label: pagy_t('pagy.aria_label.next'))
-		if (p_next = pagy.next)
-		  href = a.(p_next, text, aria_label:).match(/href="([^"]*)/)[1]
-		  %(<a href="#{href}" data-action="click->loading#show" aria-label="#{aria_label}">#{text}</a>)
-		else
-		  %(<a role="link" aria-disabled="true" aria-label="#{aria_label}">#{text}</a>)
-		end
-	end
+  def custom_pagy_nav(pagy, id: nil, aria_label: nil, **vars)
+    id = %( id="#{id}") if id
+    a = pagy_anchor(pagy, **vars)
+
+    html = %(<nav#{id} class="pagy nav" #{nav_aria_label(pagy, aria_label:)}>#{prev_a(pagy, a)})
+    pagy.series(**vars).each do |item| # series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
+      html << case item
+              when Integer
+                %(<a href="#{a.call(item).match(/href="([^"]*)/)[1]}" data-action="click->loading#show">#{item}</a>)
+              when String
+                %(<a role="link" aria-disabled="true" aria-current="page" class="current">#{pagy.label_for(item)}</a>)
+              when :gap
+                %(<a role="link" aria-disabled="true" class="gap">#{pagy_t('pagy.gap')}</a>)
+              else
+                raise InternalError, "expected item types in series to be Integer, String or :gap; got #{item.inspect}"
+              end
+    end
+    html << %(#{next_a(pagy, a)}</nav>)
+  end
+
+  # Similar to I18n.t: just ~18x faster using ~10x less memory
+  # (@pagy_locale explicitly initialized in order to avoid warning)
+  def pagy_t(key, **)
+    Pagy::I18n.translate(@pagy_locale ||= nil, key, **)
+  end
+
+  private
+
+  def nav_aria_label(pagy, aria_label: nil)
+    aria_label ||= pagy_t('pagy.aria_label.nav', count: pagy.pages)
+    %(aria-label="#{aria_label}")
+  end
+
+  def prev_a(pagy, anchor, text: pagy_t('pagy.prev'), aria_label: pagy_t('pagy.aria_label.prev'))
+    if (p_prev = pagy.prev)
+      href = anchor.call(p_prev, text, aria_label:).match(/href="([^"]*)/)[1]
+      %(<a href="#{href}" data-action="click->loading#show" aria-label="#{aria_label}">#{text}</a>)
+    else
+      %(<a role="link" aria-disabled="true" aria-label="#{aria_label}">#{text}</a>)
+    end
+  end
+
+  def next_a(pagy, anchor, text: pagy_t('pagy.next'), aria_label: pagy_t('pagy.aria_label.next'))
+    if (p_next = pagy.next)
+      href = anchor.call(p_next, text, aria_label:).match(/href="([^"]*)/)[1]
+      %(<a href="#{href}" data-action="click->loading#show" aria-label="#{aria_label}">#{text}</a>)
+    else
+      %(<a role="link" aria-disabled="true" aria-label="#{aria_label}">#{text}</a>)
+    end
+  end
 end
-	

--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -1,0 +1,53 @@
+module PagyHelper
+	def custom_pagy_nav(pagy, id: nil, aria_label: nil, **vars)
+		id = %( id="#{id}") if id
+		a = pagy_anchor(pagy, **vars)
+  
+		html = %(<nav#{id} class="pagy nav" #{nav_aria_label(pagy, aria_label:)}>#{prev_a(pagy, a)})
+		pagy.series(**vars).each do |item| # series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
+		  html << case item
+				  when Integer
+					%(<a href="#{a.(item).match(/href="([^"]*)/)[1]}" data-action="click->loading#show">#{item}</a>)
+				  when String
+					%(<a role="link" aria-disabled="true" aria-current="page" class="current">#{pagy.label_for(item)}</a>)
+				  when :gap
+					%(<a role="link" aria-disabled="true" class="gap">#{pagy_t('pagy.gap')}</a>)
+				  else
+					raise InternalError, "expected item types in series to be Integer, String or :gap; got #{item.inspect}"
+				  end
+		end
+		html << %(#{next_a(pagy, a)}</nav>)
+	end
+  
+	# Similar to I18n.t: just ~18x faster using ~10x less memory
+	# (@pagy_locale explicitly initialized in order to avoid warning)
+	def pagy_t(key, **opts)
+		Pagy::I18n.translate(@pagy_locale ||= nil, key, **opts)
+	end
+  
+	private
+  
+	def nav_aria_label(pagy, aria_label: nil)
+		aria_label ||= pagy_t('pagy.aria_label.nav', count: pagy.pages)
+		%(aria-label="#{aria_label}")
+	end
+  
+	def prev_a(pagy, a, text: pagy_t('pagy.prev'), aria_label: pagy_t('pagy.aria_label.prev'))
+		if (p_prev = pagy.prev)
+		  href = a.(p_prev, text, aria_label:).match(/href="([^"]*)/)[1]
+		  %(<a href="#{href}" data-action="click->loading#show" aria-label="#{aria_label}">#{text}</a>)
+		else
+		  %(<a role="link" aria-disabled="true" aria-label="#{aria_label}">#{text}</a>)
+		end
+	end
+  
+	def next_a(pagy, a, text: pagy_t('pagy.next'), aria_label: pagy_t('pagy.aria_label.next'))
+		if (p_next = pagy.next)
+		  href = a.(p_next, text, aria_label:).match(/href="([^"]*)/)[1]
+		  %(<a href="#{href}" data-action="click->loading#show" aria-label="#{aria_label}">#{text}</a>)
+		else
+		  %(<a role="link" aria-disabled="true" aria-label="#{aria_label}">#{text}</a>)
+		end
+	end
+end
+	

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,8 +7,8 @@ import { application } from "./application"
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import LoadingController from "./loading_controller"
+application.register("loading", LoadingController)
+
 import NestedFormController from "./nested_form_controller"
 application.register("nested-form", NestedFormController)
-
-import { Autocomplete } from "stimulus-autocomplete"
-application.register("autocomplete", Autocomplete)

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="loading"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,7 +1,21 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="loading"
+// Controller for showing loading spinner during form submission
 export default class extends Controller {
+  static targets = ["spinner"]
+
+  // 初期値
   connect() {
+    this.hide()
   }
+
+  hide() {
+    this.spinnerTarget.classList.add("hidden")
+  }
+
+  // hiddenを削除して表示
+  show() {
+    this.spinnerTarget.classList.remove("hidden")
+  }
+
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,20 +22,28 @@
     </script>
   </head>
 
-  <body style="background-image: url('<%= asset_path('background_image.jpg') %>');" class="flex flex-col min-h-screen bg-cover bg-center bg-no-repeat">
-    <% if user_signed_in? %>
-      <%= render 'shared/header' %>
-    <% else %>
-      <%= render 'shared/header_before_login' %>
-    <% end %>
+  <body data-controller="loading" style="background-image: url('<%= asset_path('background_image.jpg') %>');" class="flex flex-col min-h-screen bg-cover bg-center bg-no-repeat">
+      <!-- ローディングアニメーション -->
+        <div data-loading-target="spinner" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-white bg-opacity-50 ">
+          <div class="h-[120px] w-[120px] flex items-center justify-center">
+            <span class="loading loading-dots text-info w-full h-full"></span>
+          </div>
+        </div>
 
-    <% flash.each do |key, message| %>
-    <p class="<%= flash_class(key) %>"><%= sanitize(message) %></p>
-    <% end %>
+        <% if user_signed_in? %>
+          <%= render 'shared/header' %>
+        <% else %>
+          <%= render 'shared/header_before_login' %>
+        <% end %>
 
-    <main class="flex-grow">
-      <%= yield %>
-    </main>
-    <%= render 'shared/footer' %>
+        <% flash.each do |key, message| %>
+        <p class="<%= flash_class(key) %>"><%= sanitize(message) %></p>
+        <% end %>
+
+        <main class=" flex-grow">
+          <%= yield %>
+        </main>
+        <%= render 'shared/footer' %>
+      </div>
   </body>
 </html>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -85,7 +85,7 @@
   </div>
   <!-- 投稿ボタン -->
   <div class="flex justify-center">
-    <%= f.submit t('helpers.submit.create'),
+    <%= f.submit t('helpers.submit.create'), data: { action: "click->loading#show" },
                  class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>
   </div>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -85,7 +85,7 @@
   </div>
   <!-- 投稿ボタン -->
   <div class="flex justify-center">
-    <%= f.submit t('helpers.submit.create'), data: { action: "click->loading#show" },
-                 class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>
+    <%= f.submit t('helpers.submit.create'), data: { action: 'click->loading#show' },
+                                             class: 'bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition duration-300' %>
   </div>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -36,5 +36,5 @@
     <% end %>
   </div>
 
-  <%== pagy_nav(@pagy) %>
+  <%== custom_pagy_nav(@pagy) %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
       <% end %>
     </div>
     <nav class="sm:space-x-16">
-      <%= link_to posts_path, data: { action: "click->loading#show" }, class: 'flex flex-col items-center gap-1' do %>
+      <%= link_to posts_path, data: { action: 'click->loading#show' }, class: 'flex flex-col items-center gap-1' do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-8 sm:size-12 stroke-rose-100">
           <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
         </svg>
@@ -37,7 +37,7 @@
       </div>
       <ul tabindex="0" class="dropdown-content menu bg-gray-50 rounded-3xl z-[1] w-52 p-2 shadow-lg">
         <li>
-          <%= link_to t('header.mypage'), profile_path, data: { action: "click->loading#show" },class: 'p-2 sm:p-4  rounded-2xl' %>
+          <%= link_to t('header.mypage'), profile_path, data: { action: 'click->loading#show' }, class: 'p-2 sm:p-4  rounded-2xl' %>
         </li>
         <li>
           <%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: 'p-2 sm:p-4 rounded-2xl' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
       <% end %>
     </div>
     <nav class="sm:space-x-16">
-      <%= link_to posts_path, class: 'flex flex-col items-center gap-1' do %>
+      <%= link_to posts_path, data: { action: "click->loading#show" }, class: 'flex flex-col items-center gap-1' do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-8 sm:size-12 stroke-rose-100">
           <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
         </svg>
@@ -37,7 +37,7 @@
       </div>
       <ul tabindex="0" class="dropdown-content menu bg-gray-50 rounded-3xl z-[1] w-52 p-2 shadow-lg">
         <li>
-          <%= link_to t('header.mypage'), profile_path, class: 'p-2 sm:p-4  rounded-2xl' %>
+          <%= link_to t('header.mypage'), profile_path, data: { action: "click->loading#show" },class: 'p-2 sm:p-4  rounded-2xl' %>
         </li>
         <li>
           <%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: 'p-2 sm:p-4 rounded-2xl' %>


### PR DESCRIPTION
## issue番号
close #209 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 表示に時間がかかる一部のビューに、ローディングアニメーションを追加
  - 投稿一覧およびページネーション
  - 投稿新規作成
  - 投稿変種
  - マイページ

## やったこと
<!-- このプルリクで何をしたのか？ -->
- ローディングアニメーションをStimulusで実装
  - ローディング発火箇所
    - 投稿新規作成、編集　👉 `app/views/posts/_form.html.erb`
    - 投稿一覧、マイページ`app/views/shared/_header.html.erb`
    - ページネーション`app/helpers/pagy_helper.rb`
  - ページネーションのviewは`pagy_nav(@pagy)`のヘルパーを使用していたため、カスタムヘルパーを新規作成
    -   app/helpers/pagy_helper.rb
    - pagy github 　👉https://github.com/ddnexus/pagy/blob/3b4745cb6c550a5799a520115750f801021364ce/gem/lib/pagy/frontend.rb#L49
   
- Lint修正

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 読み込み時間が長い部分のviewの改善
- 読み込み中と容易に認識できる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- 投稿新規作成　https://gyazo.com/4bfff0e3da7950e4707d886e1d35cc0c
- 投稿一覧　https://gyazo.com/ffbc6a379da5d9fa749eefa3d4ddf6ea
- ページネーション　https://gyazo.com/bb4986bc95f205750eace9f67bc9792c
- マイページ　https://gyazo.com/60360308a69db6d04062332f1c62b8d7

## その他
<!-- レビュワーへの参考情報 -->
- 参考記事
- https://zenn.dev/hisa_dev/articles/4050eb4b658678

## 関連Issue
<!-- このPRが関連するIssue -->
- なし