### PR TITLE
style：youtubeサムネと画像サムネのサイズを調整

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -14,7 +14,7 @@
         </h4>
       <div class="my-3">
         <% if post.image.present? %>
-          <%= image_tag post.image.url, class: 'w-[400px] h-[300px] object-cover rounded-lg' %>
+          <%= image_tag post.image.url, class: 'w-[400px] h-[275px] object-cover rounded-lg' %>
         <% elsif post.post_videos.present? %>
           <div class="w-full aspect-video">
             <%= image_tag "https://img.youtube.com/vi/#{post.post_videos.first.youtube_url.to_s[0..10]}/hqdefault.jpg",


### PR DESCRIPTION
## issue番号
#19 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿一覧のyoutubeサムネイル画像と、メイン画像のサムネサイズを同じにする

## やったこと
<!-- このプルリクで何をしたのか？ -->
- viewでリサイズする大きさの修正

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- 改善前
[![Image from Gyazo](https://i.gyazo.com/852153958b245a423f78e35d75f7167e.jpg)](https://gyazo.com/852153958b245a423f78e35d75f7167e)
- 改善後
[![Image from Gyazo](https://i.gyazo.com/3e1e9310d4c7d600ff409cfe26aba20d.jpg)](https://gyazo.com/3e1e9310d4c7d600ff409cfe26aba20d)
## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし