### PR TITLE
Fix：カテゴリー検索エラー

### DIFF
--- a/app/finders/posts_finder.rb
+++ b/app/finders/posts_finder.rb
@@ -20,7 +20,7 @@ class PostsFinder
 
     keyword = like_search_condition(@q.keyword)
     @record = @record.joins(:user).where('posts.title LIKE ? OR posts.body LIKE ? OR users.name LIKE ?', keyword, keyword, keyword)
-  enda
+  end
 
   # like検索
   def like_search_condition(word)

--- a/app/finders/posts_finder.rb
+++ b/app/finders/posts_finder.rb
@@ -20,7 +20,7 @@ class PostsFinder
 
     keyword = like_search_condition(@q.keyword)
     @record = @record.joins(:user).where('posts.title LIKE ? OR posts.body LIKE ? OR users.name LIKE ?', keyword, keyword, keyword)
-  end
+  enda
 
   # like検索
   def like_search_condition(word)
@@ -31,6 +31,6 @@ class PostsFinder
     return if @q.category.blank?
 
     category = Category.find(@q.category)
-    @record = @record.where(categories: { id: category.id })
+    @record = @record.joins(:categories).where(categories: { id: category.id })
   end
 end


### PR DESCRIPTION
## issue番号
close #217 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- カテゴリー検索時にエラーが発生のため修正

## やったこと
<!-- このプルリクで何をしたのか？ -->
- エラー状況
  - カテゴリー検索時に`UndefinedTable`エラー　👉 テーブルが見つからない
- エラー原因
  - カテゴリー検索をロジックを担う`app/finders/posts_finder.rb`でカテゴリーをjoinしていなかったため
  - カテゴリーテーブルはpostテーブルと関連付けられている別テーブルのためjoinが必要だった
- 解決方法
  - `@record.joins(:categories)` 👉 カテゴリーテーブルをjoinして検索実行 ※ `@record = Post.all`

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 投稿一覧でカテゴリー検索が正常にできるようになる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルでの挙動確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし