### PR TITLE
update：サブ画像のリサイズ変更

### DIFF
--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -42,7 +42,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
     %w[jpg jpeg gif png webp]
   end
 
-  process resize_to_fill: [420, 320]
+  process resize_to_fit: [450, 450]
   process :convert_to_webp
   process :optimize
 


### PR DESCRIPTION
## issue番号


## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- サブ画像アップデート時のリサイズ内容変更
  - 変更理由
  -  現在の`resize_to_fill: [420, 320]`　だと、元画像が削られてしまうため、画像のアスペクト比（縦横比）を保ったままリサイズに変更

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `resize_to_fill: [420, 320]`　👉  `resize_to_fit: [450, 450]`

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- サブ画像が削られることなく、投稿詳細に表示

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルでの挙動確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし