### PR TITLE
Style：ユーザーアイコン未設定時のアイコンを追加

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -5,6 +5,10 @@
         <div class="flex items-center">
           <% if post.user.avatar.present? %>
             <%= image_tag post.user.avatar.url, class: 'w-12 h-12 object-cover rounded-full mr-3' %>
+          <% else %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-12 stroke-rose-400">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+            </svg>
           <% end %>
           <span class="font-semibold"><%= post.user.name %></span>
         </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,12 +1,12 @@
 <div class="w-full md:w-1/2 lg:w-1/3 px-2 mb-4">
   <%= link_to post_path(post), class: 'block' do %>
     <div class="border rounded-lg bg-gray-50 hover:shadow-lg shadow-md ">
-      <div class="pl-3 pt-3">
+      <div class="pl-4 py-4">
         <div class="flex items-center">
           <% if post.user.avatar.present? %>
             <%= image_tag post.user.avatar.url, class: 'w-12 h-12 object-cover rounded-full mr-3' %>
           <% else %>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-12 stroke-rose-400">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-12 stroke-rose-400 mr-3">
               <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
             </svg>
           <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,6 +3,10 @@
     <div class="flex items-center">
       <% if @post.user.avatar.present? %>
         <%= image_tag @post.user.avatar.url, class: 'w-16 h-16 object-cover rounded-full mr-3' %>
+      <% else %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-16 stroke-rose-400">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
       <% end %>
       <span class="font-semibold"><%= @post.user.name %><%= t('.title') %></span>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,7 @@
       <% if @post.user.avatar.present? %>
         <%= image_tag @post.user.avatar.url, class: 'w-16 h-16 object-cover rounded-full mr-3' %>
       <% else %>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-16 stroke-rose-400">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-16 stroke-rose-400 mr-3">
           <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
         </svg>
       <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -5,6 +5,10 @@
         <div class="flex flex-col items-center">
           <% if @user.avatar.present? %>
             <%= image_tag @user.avatar.url, class: 'w-32 h-32 object-cover rounded-full mb-6' %>
+          <% else %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" class="size-20 stroke-rose-400">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+            </svg>
           <% end %>
           <div class="flex items-center gap-4">
             <h1 class="text-2xl font-bold"><%= @user.name %></h1>


### PR DESCRIPTION
## issue番号


## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- ユーザーアイコン未設定時のアイコンを追加
[![Image from Gyazo](https://i.gyazo.com/68c080118eae83d8d5893a45589a1e02.png)](https://gyazo.com/68c080118eae83d8d5893a45589a1e02)
## やったこと
<!-- このプルリクで何をしたのか？ -->
- ユーザーアイコン未設定時のアイコンを追加
  - 投稿一覧
  - 投稿詳細
  - プロフィール

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- アイコンを設定できることの認知しやすさの向上

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで反家を確認

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし