### PR TITLE
feature：ご利用ガイドページ作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -6,4 +6,6 @@ class StaticPagesController < ApplicationController
   def policy; end
 
   def terms; end
+
+  def usage; end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -40,6 +40,9 @@
           <%= link_to t('header.mypage'), profile_path, data: { action: 'click->loading#show' }, class: 'p-2 sm:p-4  rounded-2xl' %>
         </li>
         <li>
+          <%= link_to t('header.usage'), usage_path, class: 'p-2 sm:p-4 rounded-2xl' %>
+        </li>
+        <li>
           <%= link_to t('header.logout'), destroy_user_session_path, data: { turbo_method: :delete }, class: 'p-2 sm:p-4 rounded-2xl' %>
         </li>
       </ul>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -25,6 +25,6 @@
   </div>
 </div>
 
-<div class="text-center">
+<div class="text-center my-12">
   <%= link_to t('.usage'), usage_path, class: 'text-lg text-blue-500 underline hover:text-blue-700' %><br>
 </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -24,3 +24,7 @@
     </div>
   </div>
 </div>
+
+<div class="text-center">
+  <%= link_to t('.usage'), usage_path, class: 'text-lg text-blue-500 underline hover:text-blue-700' %><br>
+</div>

--- a/app/views/static_pages/usage.html.erb
+++ b/app/views/static_pages/usage.html.erb
@@ -7,8 +7,9 @@
         <input type="radio" name="my-accordion-2" checked="checked" />
         <div class="collapse-title text-xl font-medium">みんなのスキ</div>
         <div class="collapse-content">
-          <p>いいね</p>
-		  <p>ブックマーク</p>
+          <p>・いいね・ブックマーク機能は、会員登録後にご利用いただけます。</p>
+		  <p>・いいねを押すと、投稿者に通知が届きます。</p>
+		  <p>・ブックマークをすると、マイページから投稿を見返すことができます（マイページは会員登録後にご利用いただけます）。</p>
         </div>
       </div>
   
@@ -16,7 +17,8 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">スキの検索</div>
         <div class="collapse-content">
-          <p>hello</p>
+          <p>・「みんなのスキ」ページ上部の検索欄から、キーワードまたはカテゴリ検索できます。</p>
+          <p>・キーワードには、ユーザー名・投稿タイトル・投稿の推しポイントなどが含まれます。</p>
         </div>
       </div>
 
@@ -24,8 +26,30 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">スキの詳細</div>
         <div class="collapse-content">
-          <p>Xシェア</p>
-		  <p>コメント</p>
+		  <p>・詳細ページ下部の編集ボタンから、自分が投稿した内容を編集できます。</p>
+		</div>
+      </div>
+
+	  <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" />
+        <div class="collapse-title text-xl font-medium">スキをXに投稿</div>
+        <div class="collapse-content">
+		  <p>・「スキの詳細」のXシェアボタンから、スキをXに投稿できます。</p>
+          <p>・Xに反映される画像は以下の通りです。</p>
+          <ul class="list-disc ml-6">
+            <li>メイン画像がある場合は、その画像が反映されます。</li>
+            <li>メイン画像がない場合は、投稿のタイトルをもとに自動生成された画像が反映されます。</li>
+          </ul>
+		</div>
+      </div>
+
+	  <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" />
+        <div class="collapse-title text-xl font-medium">スキにコメント</div>
+        <div class="collapse-content">
+          <p>・コメントの追加は、会員登録後にご利用いただけます。</p>
+          <p>・「スキの詳細」から、投稿にコメントを追加できます。</p>
+          <p>・コメントを投稿・いいねすると、投稿者に通知が届きます。</p>
         </div>
       </div>
 
@@ -33,7 +57,9 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">スキ作成</div>
         <div class="collapse-content">
-          <p>hello</p>
+          <p>・スキ作成は、会員登録後にご利用いただけます。</p>
+		  <p>・入力必須項目はカテゴリ、タイトル、推しポイントです。</p>
+		  <p>・YouTube動画URLはYouTube動画の共有ボタンからコピーしたURLを入力してください。ブラウザの上部アドレスバーのURLを入力しても反映されませんので、ご注意ください。</p>
         </div>
       </div>
 
@@ -41,7 +67,13 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">通知</div>
         <div class="collapse-content">
-          <p>hello</p>
+          <p>・通知機能は、会員登録後にご利用いただけます。</p>
+          <p>・通知が作成される条件</p>
+		    <ul class="list-disc ml-6">
+              <li>自分の投稿に他のユーザーがいいねを押したとき。</li>
+              <li>自分の投稿に他のユーザーがコメントを追加したとき。</li>
+			  <li>自分のコメントに他のユーザーがいいねを押したとき。</li>
+            </ul>
         </div>
       </div>
 
@@ -49,7 +81,9 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">マイページ</div>
         <div class="collapse-content">
-          <p>hello</p>
+          <p>・マイページは、会員登録後にご利用いただけます。</p>
+		  <p>・自分の投稿一覧・ブックマークした投稿を確認できます。</p>
+		  <p>・ユーザー名の横にある編集ボタンから、ユーザー情報を編集できます。</p>
         </div>
       </div>
 
@@ -57,10 +91,9 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">利用規約・プライバシーポリシー・お問い合わせ</div>
         <div class="collapse-content">
-          <p>hello</p>
+          <p>利用規約・プライバシーポリシー・お問い合わせは、ページ下部のフッターからアクセスできます。</p>
         </div>
       </div>
-
 	</div>
   </div>
 </div>

--- a/app/views/static_pages/usage.html.erb
+++ b/app/views/static_pages/usage.html.erb
@@ -7,9 +7,9 @@
         <input type="radio" name="my-accordion-2" checked="checked" />
         <div class="collapse-title text-xl font-medium">みんなのスキ</div>
         <div class="collapse-content">
-          <p>・いいね・ブックマーク機能は、会員登録後にご利用いただけます。</p>
+          <p>・いいね・ブックマーク機能は、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
 		  <p>・いいねを押すと、投稿者に通知が届きます。</p>
-		  <p>・ブックマークをすると、マイページから投稿を見返すことができます（マイページは会員登録後にご利用いただけます）。</p>
+		  <p>・ブックマークをすると、マイページから投稿を見返すことができます（マイページは<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます）。</p>
         </div>
       </div>
   
@@ -47,7 +47,7 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">スキにコメント</div>
         <div class="collapse-content">
-          <p>・コメントの追加は、会員登録後にご利用いただけます。</p>
+          <p>・コメントの追加は、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
           <p>・「スキの詳細」から、投稿にコメントを追加できます。</p>
           <p>・コメントを投稿・いいねすると、投稿者に通知が届きます。</p>
         </div>
@@ -57,7 +57,7 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">スキ作成</div>
         <div class="collapse-content">
-          <p>・スキ作成は、会員登録後にご利用いただけます。</p>
+          <p>・スキ作成は、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
 		  <p>・入力必須項目はカテゴリ、タイトル、推しポイントです。</p>
 		  <p>・YouTube動画URLはYouTube動画の共有ボタンからコピーしたURLを入力してください。ブラウザの上部アドレスバーのURLを入力しても反映されませんので、ご注意ください。</p>
         </div>
@@ -67,7 +67,7 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">通知</div>
         <div class="collapse-content">
-          <p>・通知機能は、会員登録後にご利用いただけます。</p>
+          <p>・通知機能は、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
           <p>・通知が作成される条件</p>
 		    <ul class="list-disc ml-6">
               <li>自分の投稿に他のユーザーがいいねを押したとき。</li>
@@ -81,7 +81,7 @@
         <input type="radio" name="my-accordion-2" />
         <div class="collapse-title text-xl font-medium">マイページ</div>
         <div class="collapse-content">
-          <p>・マイページは、会員登録後にご利用いただけます。</p>
+          <p>・マイページは、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
 		  <p>・自分の投稿一覧・ブックマークした投稿を確認できます。</p>
 		  <p>・ユーザー名の横にある編集ボタンから、ユーザー情報を編集できます。</p>
         </div>

--- a/app/views/static_pages/usage.html.erb
+++ b/app/views/static_pages/usage.html.erb
@@ -2,19 +2,19 @@
   <div class="border rounded-lg bg-gray-50 p-4 sm:p-16 text-sm sm:text-base shadow-md">
     <h1 class="text-2xl font-bold mb-12 text-center"><%= t('.title') %></h1>
 
-	<div class="space-y-4">
+  <div class="space-y-4">
       <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" checked="checked" />
+        <input type="radio" name="my-accordion-2" checked="checked">
         <div class="collapse-title text-xl font-medium">みんなのスキ</div>
         <div class="collapse-content">
           <p>・いいね・ブックマーク機能は、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
-		  <p>・いいねを押すと、投稿者に通知が届きます。</p>
-		  <p>・ブックマークをすると、マイページから投稿を見返すことができます（マイページは<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます）。</p>
+      <p>・いいねを押すと、投稿者に通知が届きます。</p>
+      <p>・ブックマークをすると、マイページから投稿を見返すことができます（マイページは<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます）。</p>
         </div>
       </div>
-  
+
       <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" />
+        <input type="radio" name="my-accordion-2">
         <div class="collapse-title text-xl font-medium">スキの検索</div>
         <div class="collapse-content">
           <p>・「みんなのスキ」ページ上部の検索欄から、キーワードまたはカテゴリ検索できます。</p>
@@ -23,28 +23,28 @@
       </div>
 
       <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" />
+        <input type="radio" name="my-accordion-2">
         <div class="collapse-title text-xl font-medium">スキの詳細</div>
         <div class="collapse-content">
-		  <p>・詳細ページ下部の編集ボタンから、自分が投稿した内容を編集できます。</p>
-		</div>
+      <p>・詳細ページ下部の編集ボタンから、自分が投稿した内容を編集できます。</p>
+    </div>
       </div>
 
-	  <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" />
+    <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2">
         <div class="collapse-title text-xl font-medium">スキをXに投稿</div>
         <div class="collapse-content">
-		  <p>・「スキの詳細」のXシェアボタンから、スキをXに投稿できます。</p>
+      <p>・「スキの詳細」のXシェアボタンから、スキをXに投稿できます。</p>
           <p>・Xに反映される画像は以下の通りです。</p>
           <ul class="list-disc ml-6">
             <li>メイン画像がある場合は、その画像が反映されます。</li>
             <li>メイン画像がない場合は、投稿のタイトルをもとに自動生成された画像が反映されます。</li>
           </ul>
-		</div>
+    </div>
       </div>
 
-	  <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" />
+    <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2">
         <div class="collapse-title text-xl font-medium">スキにコメント</div>
         <div class="collapse-content">
           <p>・コメントの追加は、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
@@ -54,46 +54,46 @@
       </div>
 
       <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" />
+        <input type="radio" name="my-accordion-2">
         <div class="collapse-title text-xl font-medium">スキ作成</div>
         <div class="collapse-content">
           <p>・スキ作成は、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
-		  <p>・入力必須項目はカテゴリ、タイトル、推しポイントです。</p>
-		  <p>・YouTube動画URLはYouTube動画の共有ボタンからコピーしたURLを入力してください。ブラウザの上部アドレスバーのURLを入力しても反映されませんので、ご注意ください。</p>
+      <p>・入力必須項目はカテゴリ、タイトル、推しポイントです。</p>
+      <p>・YouTube動画URLはYouTube動画の共有ボタンからコピーしたURLを入力してください。ブラウザの上部アドレスバーのURLを入力しても反映されませんので、ご注意ください。</p>
         </div>
       </div>
 
       <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" />
+        <input type="radio" name="my-accordion-2">
         <div class="collapse-title text-xl font-medium">通知</div>
         <div class="collapse-content">
           <p>・通知機能は、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
           <p>・通知が作成される条件</p>
-		    <ul class="list-disc ml-6">
+        <ul class="list-disc ml-6">
               <li>自分の投稿に他のユーザーがいいねを押したとき。</li>
               <li>自分の投稿に他のユーザーがコメントを追加したとき。</li>
-			  <li>自分のコメントに他のユーザーがいいねを押したとき。</li>
+        <li>自分のコメントに他のユーザーがいいねを押したとき。</li>
             </ul>
         </div>
       </div>
 
       <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" />
+        <input type="radio" name="my-accordion-2">
         <div class="collapse-title text-xl font-medium">マイページ</div>
         <div class="collapse-content">
           <p>・マイページは、<%= link_to t('.sign_up'), new_user_registration_path, class: 'text-blue-500 underline hover:text-blue-700' %>にご利用いただけます。</p>
-		  <p>・自分の投稿一覧・ブックマークした投稿を確認できます。</p>
-		  <p>・ユーザー名の横にある編集ボタンから、ユーザー情報を編集できます。</p>
+      <p>・自分の投稿一覧・ブックマークした投稿を確認できます。</p>
+      <p>・ユーザー名の横にある編集ボタンから、ユーザー情報を編集できます。</p>
         </div>
       </div>
 
       <div class="collapse collapse-arrow bg-base-200">
-        <input type="radio" name="my-accordion-2" />
+        <input type="radio" name="my-accordion-2">
         <div class="collapse-title text-xl font-medium">利用規約・プライバシーポリシー・お問い合わせ</div>
         <div class="collapse-content">
           <p>利用規約・プライバシーポリシー・お問い合わせは、ページ下部のフッターからアクセスできます。</p>
         </div>
       </div>
-	</div>
+  </div>
   </div>
 </div>

--- a/app/views/static_pages/usage.html.erb
+++ b/app/views/static_pages/usage.html.erb
@@ -1,0 +1,66 @@
+<div class="max-w-6xl mx-auto px-2 my-16">
+  <div class="border rounded-lg bg-gray-50 p-4 sm:p-16 text-sm sm:text-base shadow-md">
+    <h1 class="text-2xl font-bold mb-12 text-center"><%= t('.title') %></h1>
+
+	<div class="space-y-4">
+      <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" checked="checked" />
+        <div class="collapse-title text-xl font-medium">みんなのスキ</div>
+        <div class="collapse-content">
+          <p>いいね</p>
+		  <p>ブックマーク</p>
+        </div>
+      </div>
+  
+      <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" />
+        <div class="collapse-title text-xl font-medium">スキの検索</div>
+        <div class="collapse-content">
+          <p>hello</p>
+        </div>
+      </div>
+
+      <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" />
+        <div class="collapse-title text-xl font-medium">スキの詳細</div>
+        <div class="collapse-content">
+          <p>Xシェア</p>
+		  <p>コメント</p>
+        </div>
+      </div>
+
+      <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" />
+        <div class="collapse-title text-xl font-medium">スキ作成</div>
+        <div class="collapse-content">
+          <p>hello</p>
+        </div>
+      </div>
+
+      <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" />
+        <div class="collapse-title text-xl font-medium">通知</div>
+        <div class="collapse-content">
+          <p>hello</p>
+        </div>
+      </div>
+
+      <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" />
+        <div class="collapse-title text-xl font-medium">マイページ</div>
+        <div class="collapse-content">
+          <p>hello</p>
+        </div>
+      </div>
+
+      <div class="collapse collapse-arrow bg-base-200">
+        <input type="radio" name="my-accordion-2" />
+        <div class="collapse-title text-xl font-medium">利用規約・プライバシーポリシー・お問い合わせ</div>
+        <div class="collapse-content">
+          <p>hello</p>
+        </div>
+      </div>
+
+	</div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -19,6 +19,7 @@ ja:
       new_description: あなたの「スキ！」を投稿しましょう！投稿はXでシェアできます！
     usage:
       title: ご利用ガイド
+      sign_up: 会員登録後
   posts:
     index:
       title: 投稿一覧

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,6 +17,8 @@ ja:
     top:
       index_description: みんなの「スキ！」をのぞいてみましょう！会員登録すると、いいね・お気に入りが使えます！
       new_description: あなたの「スキ！」を投稿しましょう！投稿はXでシェアできます！
+    usage:
+      title: ご利用ガイド
   posts:
     index:
       title: 投稿一覧

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,7 @@ ja:
     sign_in: ログイン
     mypage: マイページ
     logout: ログアウト
+    usage: ご利用ガイド
   footer:
     contact: お問い合わせ
     terms: 利用規約

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,6 +17,7 @@ ja:
     top:
       index_description: みんなの「スキ！」をのぞいてみましょう！会員登録すると、いいね・お気に入りが使えます！
       new_description: あなたの「スキ！」を投稿しましょう！投稿はXでシェアできます！
+      usage: 詳しい使い方はこちらから
     usage:
       title: ご利用ガイド
       sign_up: 会員登録後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
 
   get "policy", to: "static_pages#policy", as: "privacy_policy"
   get "terms", to: "static_pages#terms", as: "terms"
+  get "usage", to: "static_pages#usage", as: "usage"
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
## issue番号
close #225 

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- ご利用ガイドページを作成。トップページとログイン後のヘッダーからアクセス可能

## やったこと
<!-- このプルリクで何をしたのか？ -->
- ご利用ガイドページを作成（app/views/static_pages/usage.html.erb）
  - 会員登録の文字にはリンクを追加して、導線確保する
- ログイン後ヘッダーと、トップページにリンクを追加
- Lint修正

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- ご利用ガイドの閲覧

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで反映を確認
[![Image from Gyazo](https://i.gyazo.com/118948bf6f8bc98f7a41aec834ca93b2.png)](https://gyazo.com/118948bf6f8bc98f7a41aec834ca93b2)

## その他
<!-- レビュワーへの参考情報 -->
- なし

## 関連Issue
<!-- このPRが関連するIssue -->
- なし