### PR TITLE
fix：検索オートコンプリート、エラー修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[index show]
+  skip_before_action :authenticate_user!, only: %i[index show search]
   before_action :set_post, only: %i[edit update destroy]
 
   def index

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("loading", LoadingController)
 
 import NestedFormController from "./nested_form_controller"
 application.register("nested-form", NestedFormController)
+
+import { Autocomplete } from "stimulus-autocomplete"
+application.register("autocomplete", Autocomplete)


### PR DESCRIPTION
## issue番号


## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- 投稿一覧、検索オートコンプリートが発動しないため修正

## やったこと
<!-- このプルリクで何をしたのか？ -->
- エラー原因
  - `app/javascript/controllers/index.js`でオートコンプリートの登録を削除してしまっていた
  - #210 の実装時に誤って削除してしまった
- 修正方法
  - `app/javascript/controllers/index.js`にオートコンプリートコントローラーを登録
　
- 未ログインだとオートコンプリートが動作しないため修正
  - `app/controllers/posts_controller.rb`、searchアクションのログイン確認をスキップ

## やらないこと
<!-- このプルリクでやらないことは何か？ -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->
- 検索オートコンプリート機能が動作する

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？ -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？ -->
- ローカルで挙動の確認

## その他
<!-- レビュワーへの参考情報 -->
- オートコンプリートはパッケージ`stimulus-autocomplete`で実装

## 関連Issue
<!-- このPRが関連するIssue -->
- なし